### PR TITLE
엔티티 재설계 및 댓글 대댓글 보기 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
@@ -1,0 +1,41 @@
+package com.junstudio.kickoff.controllers;
+
+import com.junstudio.kickoff.dtos.CommentDto;
+import com.junstudio.kickoff.dtos.CommentsDto;
+import com.junstudio.kickoff.dtos.ReCommentDto;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.services.CommentService;
+import com.junstudio.kickoff.services.RecommentService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class CommentController {
+  private final CommentService commentService;
+  private final RecommentService recommentService;
+
+  public CommentController(CommentService commentService, RecommentService recommentService) {
+    this.commentService = commentService;
+    this.recommentService = recommentService;
+  }
+
+  @GetMapping("/posts/{postId}/comments")
+  private CommentsDto comments(
+      @PathVariable Long postId
+  ) {
+    List<CommentDto> comments = commentService.findComment(postId)
+        .stream().map(Comment::toDto)
+        .collect(Collectors.toList());
+
+    List<ReCommentDto> recomments = recommentService.findReComment(postId)
+        .stream().map(Recomment::toDto)
+        .collect(Collectors.toList());
+
+    return new CommentsDto(comments, recomments);
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
@@ -1,14 +1,27 @@
 package com.junstudio.kickoff.controllers;
 
+import com.junstudio.kickoff.dtos.CategoryDto;
+import com.junstudio.kickoff.dtos.CommentDto;
 import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.PostWriteDto;
 import com.junstudio.kickoff.dtos.PostWrittenDto;
 import com.junstudio.kickoff.dtos.PostsDto;
+import com.junstudio.kickoff.dtos.ReCommentDto;
+import com.junstudio.kickoff.dtos.UserDto;
+import com.junstudio.kickoff.models.Category;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.services.CategoryService;
+import com.junstudio.kickoff.services.CommentService;
 import com.junstudio.kickoff.services.LikeService;
 import com.junstudio.kickoff.services.PostService;
+import com.junstudio.kickoff.services.RecommentService;
+import com.junstudio.kickoff.services.UserService;
 import com.junstudio.kickoff.utils.S3Uploader;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,11 +42,22 @@ public class PostsController {
   private final PostService postService;
   private final LikeService likeService;
   private final S3Uploader s3Uploader;
+  private final CommentService commentService;
+  private final UserService userService;
+  private final CategoryService categoryService;
+  private final RecommentService recommentService;
 
-  public PostsController(PostService postService, LikeService likeService, S3Uploader s3Uploader) {
+  public PostsController(PostService postService, LikeService likeService,
+                         S3Uploader s3Uploader, CommentService commentService,
+                         UserService userService, CategoryService categoryService,
+                         RecommentService recommentService) {
     this.postService = postService;
     this.likeService = likeService;
     this.s3Uploader = s3Uploader;
+    this.commentService = commentService;
+    this.userService = userService;
+    this.categoryService = categoryService;
+    this.recommentService = recommentService;
   }
 
   @GetMapping("/posts")
@@ -41,16 +65,40 @@ public class PostsController {
     List<PostDto> posts = postService.posts()
         .stream().map(Post::toDto)
         .collect(Collectors.toList());
-    return new PostsDto(posts);
+
+    List<CommentDto> comments = commentService.comments()
+        .stream().map(Comment::toDto)
+        .collect(Collectors.toList());
+
+    List<ReCommentDto> recomments = recommentService.recomments()
+        .stream().map(Recomment::toDto)
+        .collect(Collectors.toList());
+
+    List<LikeDto> likes = likeService.likes()
+        .stream().map(Like::toDto)
+        .collect(Collectors.toList());
+
+    List<UserDto> users = userService.users()
+        .stream().map(User::toDto)
+        .collect(Collectors.toList());
+
+    List<CategoryDto> categories = categoryService.categories()
+        .stream().map(Category::toDto)
+        .collect(Collectors.toList());
+
+    return new PostsDto(posts, comments, recomments, likes, users, categories);
   }
 
-  @GetMapping("/post/{id}")
+  @GetMapping("/posts/{id}")
   public PostDetailDto post(
       @PathVariable Long id
   ) {
     Post post = postService.findPost(id);
+    User user = postService.findUser(id);
+    Category category = postService.findCategory(id);
+    List<Like> likes = likeService.findLike(post.id());
 
-    return post.toDetailDto();
+    return post.toDetailDto(user, category, likes);
   }
 
   @PostMapping("/post")

--- a/src/main/java/com/junstudio/kickoff/dtos/CategoryDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/CategoryDto.java
@@ -1,0 +1,20 @@
+package com.junstudio.kickoff.dtos;
+
+public class CategoryDto {
+  private final Long id;
+
+  private final String name;
+
+  public CategoryDto(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/CommentDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/CommentDto.java
@@ -1,0 +1,49 @@
+package com.junstudio.kickoff.dtos;
+
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.models.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentDto {
+  private final Long id;
+
+  private final String content;
+
+  private final Long userId;
+
+  private final Long postId;
+
+  private final String commentDate;
+
+  public CommentDto(Long id, String content, Long userId, Long postId,
+                    String commentDate) {
+    this.id = id;
+    this.content = content;
+    this.userId = userId;
+    this.postId = postId;
+    this.commentDate = commentDate;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getPostId() {
+    return postId;
+  }
+
+  public String getCommentDate() {
+    return commentDate;
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/CommentsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/CommentsDto.java
@@ -1,0 +1,23 @@
+package com.junstudio.kickoff.dtos;
+
+import java.util.List;
+
+public class CommentsDto {
+
+  private final List<CommentDto> comments;
+
+  private final List<ReCommentDto> recomments;
+
+  public CommentsDto(List<CommentDto> comments, List<ReCommentDto> recomments) {
+    this.comments = comments;
+    this.recomments = recomments;
+  }
+
+  public List<CommentDto> getComments() {
+    return comments;
+  }
+
+  public List<ReCommentDto> getRecomments() {
+    return recomments;
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDetailDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDetailDto.java
@@ -1,44 +1,41 @@
 package com.junstudio.kickoff.dtos;
 
 import com.junstudio.kickoff.models.Category;
-import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.User;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PostDetailDto {
   private final Long id;
 
   private final String title;
 
-  private String content;
+  private final String content;
 
-  private final Category category;
+  private final CategoryDto category;
 
-  private final User user;
+  private final UserDto user;
 
   private final Long hit;
 
-  private final List<Comment> comments;
-
-  private final List<Like> likes;
+  private final List<LikeDto> likes;
 
   private final String createdAt;
 
   private final String imageUrl;
 
-  public PostDetailDto(Long id, String title, String content, Category category, User user,
-                       Long hit, List<Comment> comments, List<Like> likes,
+  public PostDetailDto(Long id, String title, String content, Long hit,
+                       List<Like> likes, User user, Category category,
                        String createdAt, String imageUrl) {
     this.id = id;
     this.title = title;
     this.content = content;
-    this.category = category;
-    this.user = user;
+    this.category = category.toDto();
+    this.user = user.toDto();
     this.hit = hit;
-    this.comments = comments;
-    this.likes = likes;
+    this.likes = likes.stream().map(Like::toLikeDto).collect(Collectors.toList());
     this.createdAt = createdAt;
     this.imageUrl = imageUrl;
   }
@@ -55,11 +52,11 @@ public class PostDetailDto {
     return content;
   }
 
-  public Category getCategory() {
+  public CategoryDto getCategory() {
     return category;
   }
 
-  public User getUser() {
+  public UserDto getUser() {
     return user;
   }
 
@@ -67,11 +64,7 @@ public class PostDetailDto {
     return hit;
   }
 
-  public List<Comment> getComments() {
-    return comments;
-  }
-
-  public List<Like> getLikes() {
+  public List<LikeDto> getLikes() {
     return likes;
   }
 

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
@@ -12,30 +12,27 @@ public class PostDto {
 
   private final String title;
 
-  private final List<Comment> comments;
+//  private final List<Comment> comments;
 
-  private final Category category;
+  private final Long categoryId;
 
-  private final User user;
+  private final Long userId;
 
   private final Long hit;
 
-  private final List<Like> likes;
+//  private final List<Like> likes;
 
   private final String createdAt;
 
   private final String imageUrl;
 
-  public PostDto(Long id, String title, List<Comment> comments,
-                 Category category, User user, Long hit,
-                 List<Like> likes, String createdAt, String imageUrl) {
+  public PostDto(Long id, String title, Long categoryId,
+                 Long userId, Long hit, String createdAt, String imageUrl) {
     this.id = id;
     this.title = title;
-    this.comments = comments;
-    this.category = category;
-    this.user = user;
+    this.categoryId = categoryId;
+    this.userId = userId;
     this.hit = hit;
-    this.likes = likes;
     this.createdAt = createdAt;
     this.imageUrl = imageUrl;
   }
@@ -48,24 +45,16 @@ public class PostDto {
     return title;
   }
 
-  public List<Comment> getComments() {
-    return comments;
+  public Long getCategoryId() {
+    return categoryId;
   }
 
-  public Category getCategory() {
-    return category;
-  }
-
-  public User getUser() {
-    return user;
+  public Long getUserId() {
+    return userId;
   }
 
   public Long getHit() {
     return hit;
-  }
-
-  public List<Like> getLikes() {
-    return likes;
   }
 
   public String getCreatedAt() {

--- a/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
@@ -5,11 +5,48 @@ import java.util.List;
 public class PostsDto {
   private final List<PostDto> posts;
 
-  public PostsDto(List<PostDto> posts) {
+  private final List<CommentDto> comments;
+
+  private final List<ReCommentDto> recomments;
+
+  private final List<LikeDto> likes;
+
+  private final List<UserDto> users;
+
+  private final List<CategoryDto> categories;
+
+  public PostsDto(List<PostDto> posts, List<CommentDto> comments,
+                  List<ReCommentDto> recomments, List<LikeDto> likes,
+                  List<UserDto> users, List<CategoryDto> categories) {
     this.posts = posts;
+    this.comments = comments;
+    this.recomments = recomments;
+    this.likes = likes;
+    this.users = users;
+    this.categories = categories;
   }
 
   public List<PostDto> getPosts() {
     return posts;
+  }
+
+  public List<CommentDto> getComments() {
+    return comments;
+  }
+
+  public List<ReCommentDto> getRecomments() {
+    return recomments;
+  }
+
+  public List<LikeDto> getLikes() {
+    return likes;
+  }
+
+  public List<UserDto> getUsers() {
+    return users;
+  }
+
+  public List<CategoryDto> getCategories() {
+    return categories;
   }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/ReCommentDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ReCommentDto.java
@@ -1,0 +1,41 @@
+package com.junstudio.kickoff.dtos;
+
+public class ReCommentDto {
+  private final Long id;
+
+  private final String content;
+
+  private final Long commentId;
+
+  private final Long postId;
+
+  private final Long userId;
+
+  public ReCommentDto(Long id, String content, Long commentId, Long postId, Long userId) {
+    this.id = id;
+    this.content = content;
+    this.commentId = commentId;
+    this.postId = postId;
+    this.userId = userId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public Long getCommentId() {
+    return commentId;
+  }
+
+  public Long getPostId() {
+    return postId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/models/Category.java
+++ b/src/main/java/com/junstudio/kickoff/models/Category.java
@@ -1,45 +1,38 @@
 package com.junstudio.kickoff.models;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.junstudio.kickoff.dtos.CategoryDto;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 public class Category {
-  @Id @GeneratedValue
+  @Id
+  @GeneratedValue
   @Column(name = "category_id")
   private Long id;
 
   private String name;
 
-  @JsonManagedReference
-  @OneToMany(mappedBy = "category")
-  private List<Post> posts = new ArrayList<>();
-
   public Category() {
   }
 
-  public Category(Long id, String name, List<Post> posts) {
+  public Category(Long id, String name) {
     this.id = id;
     this.name = name;
-    this.posts = posts;
   }
 
-  public Long getId() {
+  public Long id() {
     return id;
   }
 
-  public String getName() {
+  public String name() {
     return name;
   }
 
-  public List<Post> getPosts() {
-    return posts;
+  public CategoryDto toDto() {
+    return new CategoryDto(id, name);
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Grade.java
+++ b/src/main/java/com/junstudio/kickoff/models/Grade.java
@@ -1,33 +1,25 @@
 package com.junstudio.kickoff.models;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 public class Grade {
-  @Id @GeneratedValue
+  @Id
+  @GeneratedValue
   @Column(name = "grade_id")
   private Long id;
 
   private String name;
 
-  @OneToMany(mappedBy = "grade")
-  private List<User> users = new ArrayList<>();
-
   public Grade() {
   }
 
-  public Grade(Long id, String name, List<User> users) {
+  public Grade(Long id, String name) {
     this.id = id;
     this.name = name;
-    this.users = users;
   }
 
   public Long getId() {
@@ -36,9 +28,5 @@ public class Grade {
 
   public String getName() {
     return name;
-  }
-
-  public List<User> getUsers() {
-    return users;
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Like.java
+++ b/src/main/java/com/junstudio/kickoff/models/Like.java
@@ -1,55 +1,57 @@
 package com.junstudio.kickoff.models;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.junstudio.kickoff.dtos.LikeDto;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "LIKES")
 public class Like {
-  @Id @GeneratedValue
+  @Id
+  @GeneratedValue
   @Column(name = "like_id")
   private Long id;
 
-  @JsonBackReference
-  @ManyToOne
-  @JoinColumn(name = "post_id")
-  private Post post;
+  private Long postId;
 
-  @JsonBackReference
-  @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
+
+  private Long userId;
 
   public Like() {
   }
 
-  public Like(Long id, Post post, User user) {
+  public Like(Long id, Long postId, Long userId) {
     this.id = id;
-    this.post = post;
-    this.user = user;
+    this.postId = postId;
+    this.userId = userId;
   }
 
-  public Like(Post post, User user) {
-    this.post = post;
-    this.user = user;
+  public Like(Long postId, Long userId) {
+    this.postId = postId;
+    this.userId = userId;
   }
 
-  public Long getId() {
+  public Long id() {
     return id;
   }
 
-  public Post getPost() {
-    return post;
+  public Long postId() {
+    return postId;
   }
 
-  public User getUser() {
-    return user;
+  public Long userId() {
+    return userId;
+  }
+
+  public LikeDto toDto() {
+    return new LikeDto(id, postId, userId);
+  }
+
+  public LikeDto toLikeDto() {
+    return new LikeDto(id, postId, userId);
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Post.java
+++ b/src/main/java/com/junstudio/kickoff/models/Post.java
@@ -1,7 +1,5 @@
 package com.junstudio.kickoff.models;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.PostWrittenDto;
@@ -11,12 +9,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -26,23 +20,9 @@ public class Post {
   @Column(name = "post_id")
   private Long id;
 
-  @JsonBackReference
-  @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
+  private Long userId;
 
-  @JsonBackReference
-  @ManyToOne
-  @JoinColumn(name = "category_id")
-  private Category category;
-
-  @JsonManagedReference
-  @OneToMany(mappedBy = "post")
-  private List<Comment> comments = new ArrayList<>();
-
-  @JsonManagedReference
-  @OneToMany(mappedBy = "post")
-  private List<Like> likes = new ArrayList<>();
+  private Long categoryId;
 
   private String title;
 
@@ -59,14 +39,12 @@ public class Post {
   public Post() {
   }
 
-  public Post(Long id, User user, Category category,
-              List<Comment> comments, List<Like> likes, String title,
-              String content, Long hit, String imageUrl, LocalDateTime createdAt) {
+  public Post(Long id, Long userId, Long categoryId, String title,
+              String content, Long hit, String imageUrl,
+              LocalDateTime createdAt) {
     this.id = id;
-    this.user = user;
-    this.category = category;
-    this.comments = comments;
-    this.likes = likes;
+    this.userId = userId;
+    this.categoryId = categoryId;
     this.title = title;
     this.content = content;
     this.hit = hit;
@@ -75,64 +53,53 @@ public class Post {
   }
 
   public Post(String title, String content, Long hit,
-              String imageUrl, User user, Category category) {
+              String imageUrl, Long userId, Long categoryId) {
     this.title = title;
     this.content = content;
     this.hit = hit;
     this.imageUrl = imageUrl;
-    this.user = user;
-    this.category = category;
+    this.userId = userId;
+    this.categoryId = categoryId;
   }
 
-  public Long getId() {
+  public Long id() {
     return id;
   }
 
-  public User getUser() {
-    return user;
+  public Long userId() {
+    return userId;
   }
 
-  public Category getCategory() {
-    return category;
+  public Long categoryId() {
+    return categoryId;
   }
 
-  public List<Comment> getComments() {
-    return comments;
-  }
 
-  public List<Like> getLikes() {
-    return likes;
-  }
-
-  public String getTitle() {
+  public String title() {
     return title;
   }
 
-  public String getContent() {
+  public String content() {
     return content;
   }
 
-  public Long getHit() {
+  public Long hit() {
     return hit;
   }
 
-  public String getImageUrl() {
+  public String imageUrl() {
     return imageUrl;
   }
 
-  public LocalDateTime getCreatedAt() {
+  public LocalDateTime createdAt() {
     return createdAt;
   }
 
   public PostDto toDto() {
-    return new PostDto(id, title, comments, category, user, hit, likes,
+    return new PostDto(id, title, categoryId, userId, hit,
         createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), imageUrl);
   }
 
-  public PostDetailDto toDetailDto() {
-    return new PostDetailDto(id, title, content, category, user, hit, comments, likes,
-        createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), imageUrl);
-  }
 
   public void updateHit(Long hit) {
     this.hit = hit + 1L;
@@ -140,5 +107,10 @@ public class Post {
 
   public PostWrittenDto postWrittenDto() {
     return new PostWrittenDto(id);
+  }
+
+  public PostDetailDto toDetailDto(User user, Category category, List<Like> likes) {
+    return new PostDetailDto(id, title, content, hit, likes, user, category,
+        createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), imageUrl);
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -1,6 +1,6 @@
 package com.junstudio.kickoff.models;
 
-import com.junstudio.kickoff.dtos.CommentDto;
+import com.junstudio.kickoff.dtos.ReCommentDto;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.Column;
@@ -8,14 +8,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Entity
-public class Comment {
-  @Id
-  @GeneratedValue
-  @Column(name = "comment_id")
+public class Recomment {
+  @Id @GeneratedValue
+  @Column(name = "recomment_id")
   private Long id;
+
+  private Long commentId;
 
   private String content;
 
@@ -26,40 +26,44 @@ public class Comment {
   @CreationTimestamp
   private LocalDateTime commentDate;
 
-  public Comment() {
+  public Recomment() {
   }
 
-  public Comment(Long id, String content, Long userId, Long postId,
-                 LocalDateTime commentDate) {
+  public Recomment(Long id, Long commentId, String content,
+                   Long userId, Long postId, LocalDateTime commentDate) {
     this.id = id;
+    this.commentId = commentId;
     this.content = content;
     this.userId = userId;
     this.postId = postId;
     this.commentDate = commentDate;
   }
 
-  public Long id() {
+  public Long getId() {
     return id;
   }
 
-  public String content() {
+  public Long getCommentId() {
+    return commentId;
+  }
+
+  public String getContent() {
     return content;
   }
 
-  public Long userId() {
+  public Long getUserId() {
     return userId;
   }
 
-  public Long postId() {
+  public Long getPostId() {
     return postId;
   }
 
-  public LocalDateTime commentDate() {
+  public LocalDateTime getCommentDate() {
     return commentDate;
   }
 
-  public CommentDto toDto() {
-    return new CommentDto(id, content, userId, postId,
-        commentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+  public ReCommentDto toDto() {
+    return new ReCommentDto(id, content, commentId, postId, userId);
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -1,19 +1,12 @@
 package com.junstudio.kickoff.models;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.junstudio.kickoff.dtos.UserDto;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "PERSON")
@@ -31,65 +24,44 @@ public class User {
 
   private String profileImage;
 
-  @JsonBackReference
-  @ManyToOne
-  @JoinColumn(name = "grade_id")
-  private Grade grade;
 
-  @JsonManagedReference
-  @OneToMany(mappedBy = "user")
-  private List<Post> posts = new ArrayList<>();
-
-  @JsonManagedReference
-  @OneToMany(mappedBy = "user")
-  private List<Comment> comments = new ArrayList<>();
+  private Long gradeId;
 
   public User() {
   }
 
   public User(Long id, String identification, String encodedPassword,
-              String name, String profileImage, Grade grade,
-              List<Post> posts, List<Comment> comments) {
+              String name, String profileImage, Long gradeId) {
     this.id = id;
     this.identification = identification;
     this.encodedPassword = encodedPassword;
     this.name = name;
     this.profileImage = profileImage;
-    this.grade = grade;
-    this.posts = posts;
-    this.comments = comments;
+    this.gradeId = gradeId;
   }
 
-  public Long getId() {
+  public Long id() {
     return id;
   }
 
-  public String getIdentification() {
+  public String identification() {
     return identification;
   }
 
-  public String getEncodedPassword() {
+  public String encodedPassword() {
     return encodedPassword;
   }
 
-  public String getName() {
+  public String name() {
     return name;
   }
 
-  public String getProfileImage() {
+  public String profileImage() {
     return profileImage;
   }
 
-  public Grade getGrade() {
-    return grade;
-  }
-
-  public List<Post> getPosts() {
-    return posts;
-  }
-
-  public List<Comment> getComments() {
-    return comments;
+  public Long gradeId() {
+    return gradeId;
   }
 
   public UserDto toDto() {

--- a/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.junstudio.kickoff.repositories;
+
+import com.junstudio.kickoff.models.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+  List<Comment> findAllByPostId(Long postId);
+}

--- a/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
@@ -3,8 +3,11 @@ package com.junstudio.kickoff.repositories;
 import com.junstudio.kickoff.models.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
   Optional<Like> findByPostId(Long postId);
+
+  List<Like> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
@@ -1,0 +1,10 @@
+package com.junstudio.kickoff.repositories;
+
+import com.junstudio.kickoff.models.Recomment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecommentRepository extends JpaRepository<Recomment, Long> {
+  List<Recomment> findAllByPostId(Long postId);
+}

--- a/src/main/java/com/junstudio/kickoff/services/CategoryService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CategoryService.java
@@ -1,0 +1,22 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Category;
+import com.junstudio.kickoff.repositories.CategoryRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+public class CategoryService {
+  private final CategoryRepository categoryRepository;
+
+  public CategoryService(CategoryRepository categoryRepository) {
+    this.categoryRepository = categoryRepository;
+  }
+
+  public List<Category> categories() {
+    return categoryRepository.findAll();
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/services/CommentService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CommentService.java
@@ -1,0 +1,29 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+public class CommentService {
+  private final CommentRepository commentRepository;
+  private final PostRepository postRepository;
+
+  public CommentService(CommentRepository commentRepository, PostRepository postRepository) {
+    this.commentRepository = commentRepository;
+    this.postRepository = postRepository;
+  }
+
+  public List<Comment> comments() {
+    return commentRepository.findAll();
+  }
+
+  public List<Comment> findComment(Long postId) {
+    return commentRepository.findAllByPostId(postId);
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/services/LikeService.java
+++ b/src/main/java/com/junstudio/kickoff/services/LikeService.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.exceptions.PostNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.Like;
@@ -11,6 +12,7 @@ import com.junstudio.kickoff.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -32,17 +34,25 @@ public class LikeService {
     Post post = postRepository.findById(postId).orElseThrow(PostNotFound::new);
     User user = userRepository.findById(userId).orElseThrow(UserNotFound::new);
 
-    Like like = new Like(-1L, post, user);
+    Like like = new Like(-1L, post.id(), user.id());
     Like foundLike = likeRepository.findByPostId(postId).orElse(like);
 
     if (!(foundLike.equals(like))) {
-      if (Objects.equals(foundLike.getUser().getId(), userId)) {
-        likeRepository.deleteById(foundLike.getId());
+      if (Objects.equals(foundLike.userId(), userId)) {
+        likeRepository.deleteById(foundLike.id());
         return;
       }
     }
 
-    Like newLike = new Like(post, user);
+    Like newLike = new Like(post.id(), user.id());
     likeRepository.save(newLike);
+  }
+
+  public List<Like> likes() {
+    return likeRepository.findAll();
+  }
+
+  public List<Like> findLike(Long postId) {
+    return likeRepository.findAllByPostId(postId);
   }
 }

--- a/src/main/java/com/junstudio/kickoff/services/PostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/PostService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -31,8 +30,24 @@ public class PostService {
 
   public Post findPost(Long postId) {
     Post post = postRepository.findById(postId).orElseThrow(PostNotFound::new);
-    post.updateHit(post.getHit());
+
+    post.updateHit(post.hit());
+
     return post;
+  }
+
+  public User findUser(Long postId) {
+    Post post = postRepository.findById(postId).orElseThrow(UserNotFound::new);
+
+    return userRepository.findById(post.userId())
+        .orElseThrow(UserNotFound::new);
+  }
+
+  public Category findCategory(Long postId) {
+    Post post = postRepository.findById(postId).orElseThrow(CategoryNotFound::new);
+
+    return categoryRepository.findById(post.categoryId())
+        .orElseThrow(CategoryNotFound::new);
   }
 
   public List<Post> posts() {
@@ -44,7 +59,7 @@ public class PostService {
     User user = userRepository.findById(userId).orElseThrow(UserNotFound::new);
     Category category = categoryRepository.findById(categoryId).orElseThrow(CategoryNotFound::new);
 
-    Post post = new Post(title, content, 0L, imageUrl, user, category);
+    Post post = new Post(title, content, 0L, imageUrl, user.id(), category.id());
 
     postRepository.save(post);
     return post;

--- a/src/main/java/com/junstudio/kickoff/services/RecommentService.java
+++ b/src/main/java/com/junstudio/kickoff/services/RecommentService.java
@@ -1,0 +1,26 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+public class RecommentService {
+  private final RecommentRepository recommentRepository;
+
+  public RecommentService(RecommentRepository recommentRepository) {
+    this.recommentRepository = recommentRepository;
+  }
+
+  public List<Recomment> recomments() {
+    return recommentRepository.findAll();
+  }
+
+  public List<Recomment> findReComment(Long postId) {
+    return recommentRepository.findAllByPostId(postId);
+  }
+}

--- a/src/main/java/com/junstudio/kickoff/services/UserService.java
+++ b/src/main/java/com/junstudio/kickoff/services/UserService.java
@@ -1,11 +1,13 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.dtos.UserDto;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -18,5 +20,9 @@ public class UserService {
 
   public User findUser(Long userId) {
     return userRepository.findById(userId).orElseThrow(UserNotFound::new);
+  }
+
+  public List<User> users() {
+    return userRepository.findAll();
   }
 }

--- a/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
@@ -1,8 +1,10 @@
 package com.junstudio.kickoff.controllers;
 
-import com.junstudio.kickoff.models.Grade;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.User;
-import com.junstudio.kickoff.services.UserService;
+import com.junstudio.kickoff.services.CommentService;
+import com.junstudio.kickoff.services.RecommentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -18,26 +21,29 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(UserController.class)
+@WebMvcTest(CommentController.class)
 @ActiveProfiles("test")
-class UserControllerTest {
+class
+CommentControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
   @MockBean
-  private UserService userService;
+  private CommentService commentService;
+
+  @MockBean
+  private RecommentService recommentService;
 
   @Test
-  void user() throws Exception {
-    User user = new User(1L, "jel1y", "encodedPassword",
-        "Jun", "profileImage", 1L);
+  void comment() throws Exception {
+    Comment comment = new Comment(1L, "reply", 1L, 1L, LocalDateTime.now());
 
-    given(userService.findUser(1L)).willReturn(user);
+    given(commentService.findComment(1L)).willReturn(List.of(comment));
 
-    mockMvc.perform(MockMvcRequestBuilders.get("/users/me"))
+    mockMvc.perform(MockMvcRequestBuilders.get("/posts/1/comments"))
         .andExpect(status().isOk())
         .andExpect(content().string(
-            containsString("jel1y")
+            containsString("\"content\":\"reply\"")
         ));
   }
 }

--- a/src/test/java/com/junstudio/kickoff/models/CategoryTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/CategoryTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CategoryTest {
   @Test
   void category() {
-    Category category = new Category(1L, "EPL", List.of());
+    Category category = new Category(1L, "EPL");
 
-    assertThat(category.getName()).isEqualTo("EPL");
+    assertThat(category.name()).isEqualTo("EPL");
   }
 }

--- a/src/test/java/com/junstudio/kickoff/models/CommentTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/CommentTest.java
@@ -3,14 +3,15 @@ package com.junstudio.kickoff.models;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CommentTest {
   @Test
   void comment() {
-    Comment comment = new Comment(1L, "reply", new User(), new Post(), LocalDateTime.now());
+    Comment comment = new Comment(1L, "reply", 1L, 1L, LocalDateTime.now());
 
-    assertThat(comment.getContent()).isEqualTo("reply");
+    assertThat(comment.content()).isEqualTo("reply");
   }
 }

--- a/src/test/java/com/junstudio/kickoff/models/GradeTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/GradeTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GradeTest {
   @Test
   void grade() {
-    Grade grade = new Grade(1L, "WorldClass", List.of());
+    Grade grade = new Grade(1L, "WorldClass");
 
     assertThat(grade.getName()).isEqualTo("WorldClass");
   }

--- a/src/test/java/com/junstudio/kickoff/models/LikeTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/LikeTest.java
@@ -11,14 +11,14 @@ class LikeTest {
   @Test
   void like() {
     User user = new User(1L, "jel1y", "encodedPassword",
-        "Jun","profileImage", new Grade(), List.of(), List.of());
+        "Jun", "profileImage", 1L);
 
-    Category category = new Category(1L, "EPL", List.of());
+    Category category = new Category(1L, "EPL");
 
-    Post post = new Post(1L, user, category, List.of(), List.of(),
-        "손흥민 득점왕 수상", "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
-    Like like = new Like(1L, post, user);
+    Post post = new Post(2L, 1L, 1L, "손흥민 득점왕 수상",
+        "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
+    Like like = new Like(1L, post.id(), user.id());
 
-    assertThat(like.getPost().getTitle()).isEqualTo("손흥민 득점왕 수상");
+    assertThat(like.postId()).isEqualTo(2L);
   }
 }

--- a/src/test/java/com/junstudio/kickoff/models/PostTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/PostTest.java
@@ -14,23 +14,23 @@ class PostTest {
   @BeforeEach
   void setup() {
     User user = new User(1L, "jel1y", "encodedPassword",
-        "Jun", "profileImage", new Grade(), List.of(), List.of());
+        "Jun", "profileImage", 1L);
 
-    Category category = new Category(1L, "EPL", List.of());
+    Category category = new Category(1L, "EPL");
 
-    post = new Post(1L, user, category, List.of(), List.of(),
-        "손흥민 득점왕 수상", "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
+    post = new Post(1L, 1L, 1L, "손흥민 득점왕 수상",
+        "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
   }
 
   @Test
   void creation() {
-    assertThat(post.getTitle()).isEqualTo("손흥민 득점왕 수상");
+    assertThat(post.title()).isEqualTo("손흥민 득점왕 수상");
   }
 
   @Test
   void updateHit() {
-    post.updateHit(post.getHit());
+    post.updateHit(post.hit());
 
-    assertThat(post.getHit()).isEqualTo(4L);
+    assertThat(post.hit()).isEqualTo(4L);
   }
 }

--- a/src/test/java/com/junstudio/kickoff/models/RecommentTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/RecommentTest.java
@@ -1,0 +1,16 @@
+package com.junstudio.kickoff.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecommentTest {
+  @Test
+  void recomment() {
+    Recomment recomment = new Recomment(1L, 1L, "대댓글", 1L, 1L, LocalDateTime.now());
+
+    assertThat(recomment.getContent()).isEqualTo("대댓글");
+  }
+}

--- a/src/test/java/com/junstudio/kickoff/models/UserTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/UserTest.java
@@ -2,17 +2,15 @@ package com.junstudio.kickoff.models;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
   @Test
   void User() {
     User user = new User(1L, "jel1y", "encodedPassword",
-        "Jun", "profileImage", new Grade(), List.of(), List.of());
+        "Jun", "profileImage", 1L);
 
-    assertThat(user.getIdentification()).isEqualTo("jel1y");
-    assertThat(user.getName()).isEqualTo("Jun");
+    assertThat(user.identification()).isEqualTo("jel1y");
+    assertThat(user.name()).isEqualTo("Jun");
   }
 }

--- a/src/test/java/com/junstudio/kickoff/services/CommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CommentServiceTest.java
@@ -1,0 +1,62 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class CommentServiceTest {
+  @MockBean
+  private CommentRepository commentRepository;
+
+  @MockBean
+  private PostRepository postRepository;
+
+  @MockBean
+  private CommentService commentService;
+
+  @BeforeEach
+  void setup() {
+    commentRepository = mock(CommentRepository.class);
+    postRepository = mock(PostRepository.class);
+
+    commentService = new CommentService(commentRepository, postRepository);
+  }
+
+  @Test
+  void comments() {
+    Comment comment = mock(Comment.class);
+
+    given(commentRepository.findAll()).willReturn(List.of(comment));
+
+    List<Comment> comments = commentService.comments();
+
+    assertThat(comments).hasSize(1);
+  }
+
+  @Test
+  void findComment() {
+    Comment comment = new Comment(1L, "댓긍릐 댓글", 1L, 1L, LocalDateTime.now());
+
+    given(commentRepository.findAllByPostId(any(Long.class)))
+        .willReturn(List.of(comment));
+
+    List<Comment> comments = commentService.findComment(1L);
+
+    assertThat(comments).hasSize(1);
+  }
+
+
+}

--- a/src/test/java/com/junstudio/kickoff/services/LikeServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/LikeServiceTest.java
@@ -31,9 +31,11 @@ class LikeServiceTest {
   @SpyBean
   private LikeService likeService;
 
-  User user;
-  Post post;
-  Like like;
+  private User user;
+
+  private Post post;
+
+  private Like like;
 
   @BeforeEach
   void setup() {
@@ -53,20 +55,20 @@ class LikeServiceTest {
 
   @Test
   void countLike() {
-    like = new Like(1L, post, user);
+    like = new Like(1L, post.id(), user.id());
 
-    likeService.countLike(user.getId(), post.getId());
+    likeService.countLike(user.id(), post.id());
     verify(likeRepository).save(any());
   }
 
   @Test
   void deleteLike() {
-    like = new Like(1L, post, user);
+    like = new Like(1L, post.id(), user.id());
 
     given(likeRepository.findByPostId(any(Long.class)))
         .willReturn(Optional.of(like));
 
-    likeService.countLike(post.getId(), user.getId());
+    likeService.countLike(post.id(), user.id());
     verify(likeRepository).deleteById(any(Long.class));
   }
 }

--- a/src/test/java/com/junstudio/kickoff/services/PostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PostServiceTest.java
@@ -47,14 +47,14 @@ class PostServiceTest {
 
   @Test
   void findPost() {
-    Post post = new Post(1L, new User(), new Category(), List.of(), List.of(),
-        "EPL start", "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
+    Post post = new Post(1L, 1L, 1L, "EPL start",
+        "손흥민 아시아인 최초 EPL 득점왕", 3L, "imageUrl", LocalDateTime.now());
 
     given(postRepository.findById(any())).willReturn(Optional.of(post));
 
-    Post foundedPost = postService.findPost(post.getId());
+    Post foundedPost = postService.findPost(post.id());
 
-    assertThat(foundedPost.getTitle()).isEqualTo("EPL start");
+    assertThat(foundedPost.title()).isEqualTo("EPL start");
 
     verify(postRepository).findById(any());
   }
@@ -62,15 +62,15 @@ class PostServiceTest {
   @Test
   void write() {
     User user = mock(User.class);
-    given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+    given(userRepository.findById(user.id())).willReturn(Optional.of(user));
 
     Category category = mock(Category.class);
-    given(categoryRepository.findById(category.getId())).willReturn(Optional.of(category));
+    given(categoryRepository.findById(category.id())).willReturn(Optional.of(category));
 
-    Post post = new Post("conte", "reshuffle", 1L, "imageUrl", user, category);
+    Post post = new Post("conte", "reshuffle", 1L, "imageUrl", user.id(), category.id());
 
-    postService.write(post.getTitle(), post.getContent(),
-        post.getImageUrl(), post.getUser().getId(), post.getCategory().getId());
+    postService.write(post.title(), post.content(),
+        post.imageUrl(), user.id(), category.id());
 
     given(postRepository.save(post)).willReturn(post);
 

--- a/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
@@ -1,0 +1,56 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class RecommentServiceTest {
+  @MockBean
+  private RecommentRepository recommentRepository;
+
+  @MockBean
+  private RecommentService recommentService;
+
+  @BeforeEach
+  void setup() {
+    recommentRepository = mock(RecommentRepository.class);
+
+    recommentService = new RecommentService(recommentRepository);
+  }
+
+  @Test
+  void recomments() {
+    Recomment recomment = mock(Recomment.class);
+
+    given(recommentRepository.findAll())
+        .willReturn(List.of(recomment, new Recomment()));
+
+    List<Recomment> recomments = recommentService.recomments();
+
+    assertThat(recomments).hasSize(2);
+  }
+
+  @Test
+  void findReComment() {
+    Recomment recomment = mock(Recomment.class);
+
+    given(recommentRepository.findAllByPostId(any(Long.class)))
+        .willReturn(List.of(recomment));
+
+    List<Recomment> recomments = recommentService.findReComment(any(Long.class));
+
+    assertThat(recomments).hasSize(1);
+  }
+
+}

--- a/src/test/java/com/junstudio/kickoff/services/UserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/UserServiceTest.java
@@ -20,12 +20,12 @@ class UserServiceTest {
     UserService userService = new UserService(userRepository);
 
     User user = new User(1L, "jel1y", "encodedPassword",
-        "Jun", "profileImage", new Grade(), List.of(), List.of());
+        "Jun", "profileImage", 1L);
 
     given(userRepository.findById(any(Long.class))).willReturn(Optional.of(user));
 
     User foundUser = userService.findUser(1L);
 
-    assertThat(foundUser.getName()).isEqualTo("Jun");
+    assertThat(foundUser.name()).isEqualTo("Jun");
   }
 }


### PR DESCRIPTION
- @ManyToOne, @OneToMany 제거하고 dto로 객체들을 전달
- 게시글 아이디에 해당하는 댓글만 레파지토리에서 찾아 전달
- 전체 댓글 수를 알기 위해 게시글을 GET할때  전체 댓글과 대댓글도 전달