### PR TITLE
댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
@@ -7,8 +7,12 @@ import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.services.CommentService;
 import com.junstudio.kickoff.services.RecommentService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -37,5 +41,17 @@ public class CommentController {
         .collect(Collectors.toList());
 
     return new CommentsDto(comments, recomments);
+  }
+
+  @PostMapping("/comment")
+  @ResponseStatus(HttpStatus.CREATED)
+  private String comment(
+      @RequestBody CommentDto commentDto
+  ) {
+    commentService.createComment(
+        commentDto.getContent(),
+        commentDto.getUserId(),
+        commentDto.getPostId());
+    return "ok";
   }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/CommentDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/CommentDto.java
@@ -1,12 +1,5 @@
 package com.junstudio.kickoff.dtos;
 
-import com.junstudio.kickoff.models.Comment;
-import com.junstudio.kickoff.models.Post;
-import com.junstudio.kickoff.models.User;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class CommentDto {
   private final Long id;
 

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
@@ -1,26 +1,15 @@
 package com.junstudio.kickoff.dtos;
 
-import com.junstudio.kickoff.models.Category;
-import com.junstudio.kickoff.models.Comment;
-import com.junstudio.kickoff.models.Like;
-import com.junstudio.kickoff.models.User;
-
-import java.util.List;
-
 public class PostDto {
   private final Long id;
 
   private final String title;
-
-//  private final List<Comment> comments;
 
   private final Long categoryId;
 
   private final Long userId;
 
   private final Long hit;
-
-//  private final List<Like> likes;
 
   private final String createdAt;
 

--- a/src/main/java/com/junstudio/kickoff/dtos/ReCommentDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ReCommentDto.java
@@ -11,12 +11,16 @@ public class ReCommentDto {
 
   private final Long userId;
 
-  public ReCommentDto(Long id, String content, Long commentId, Long postId, Long userId) {
+  private final String commentDate;
+
+  public ReCommentDto(Long id, String content, Long commentId, Long postId,
+                      Long userId, String commentDate) {
     this.id = id;
     this.content = content;
     this.commentId = commentId;
     this.postId = postId;
     this.userId = userId;
+    this.commentDate = commentDate;
   }
 
   public Long getId() {
@@ -37,5 +41,9 @@ public class ReCommentDto {
 
   public Long getUserId() {
     return userId;
+  }
+
+  public String getCommentDate() {
+    return commentDate;
   }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
@@ -1,7 +1,5 @@
 package com.junstudio.kickoff.dtos;
 
-import com.junstudio.kickoff.models.Grade;
-
 public class UserDto {
   private final Long id;
 

--- a/src/main/java/com/junstudio/kickoff/models/Comment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Comment.java
@@ -38,6 +38,12 @@ public class Comment {
     this.commentDate = commentDate;
   }
 
+  public Comment(String content, Long userId, Long postId) {
+    this.content = content;
+    this.userId = userId;
+    this.postId = postId;
+  }
+
   public Long id() {
     return id;
   }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 public class Recomment {
@@ -64,6 +65,7 @@ public class Recomment {
   }
 
   public ReCommentDto toDto() {
-    return new ReCommentDto(id, content, commentId, postId, userId);
+    return new ReCommentDto(id, content, commentId, postId, userId,
+        commentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
   }
 }

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -24,7 +24,6 @@ public class User {
 
   private String profileImage;
 
-
   private Long gradeId;
 
   public User() {

--- a/src/main/java/com/junstudio/kickoff/services/CommentService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CommentService.java
@@ -26,4 +26,10 @@ public class CommentService {
   public List<Comment> findComment(Long postId) {
     return commentRepository.findAllByPostId(postId);
   }
+
+  public void createComment(String content, Long userId, Long postId) {
+    Comment comment = new Comment(content, userId, postId);
+
+    commentRepository.save(comment);
+  }
 }

--- a/src/main/java/com/junstudio/kickoff/services/LikeService.java
+++ b/src/main/java/com/junstudio/kickoff/services/LikeService.java
@@ -1,6 +1,5 @@
 package com.junstudio.kickoff.services;
 
-import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.exceptions.PostNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.Like;

--- a/src/main/java/com/junstudio/kickoff/services/UserService.java
+++ b/src/main/java/com/junstudio/kickoff/services/UserService.java
@@ -1,6 +1,5 @@
 package com.junstudio.kickoff.services;
 
-import com.junstudio.kickoff.dtos.UserDto;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.UserRepository;

--- a/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -45,5 +46,18 @@ CommentControllerTest {
         .andExpect(content().string(
             containsString("\"content\":\"reply\"")
         ));
+  }
+
+  @Test
+  void writeComment() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/comment")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{" +
+                "\"content\":\"comment\"," +
+                "\"userId\":\"1\"," +
+                "\"postId\":\"1\"" +
+                "}"))
+        .andExpect(status().isCreated());
   }
 }

--- a/src/test/java/com/junstudio/kickoff/services/CommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CommentServiceTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class CommentServiceTest {
   @MockBean
@@ -58,5 +59,12 @@ class CommentServiceTest {
     assertThat(comments).hasSize(1);
   }
 
+  @Test
+  void createComment() {
+    Comment comment = mock(Comment.class);
 
+    commentService.createComment(comment.content(), comment.userId(), comment.postId());
+
+    verify(commentRepository).save(any(Comment.class));
+  }
 }

--- a/src/test/java/com/junstudio/kickoff/services/PostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PostServiceTest.java
@@ -72,8 +72,6 @@ class PostServiceTest {
     postService.write(post.title(), post.content(),
         post.imageUrl(), user.id(), category.id());
 
-    given(postRepository.save(post)).willReturn(post);
-
     verify(postRepository).save(any(Post.class));
   }
 }

--- a/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
@@ -52,5 +52,4 @@ class RecommentServiceTest {
 
     assertThat(recomments).hasSize(1);
   }
-
 }


### PR DESCRIPTION
- REST API POST/comment
- 프론트엔드에서 댓글 내용과, 댓글을 쓴 유저의 아이디, 댓글을 단 게시글의 아이디를 받아 저장