### PR TITLE
대댓글 작성 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/CommentController.java
@@ -54,4 +54,19 @@ public class CommentController {
         commentDto.getPostId());
     return "ok";
   }
+
+  @PostMapping("/recomment")
+  @ResponseStatus(HttpStatus.CREATED)
+  private String recomment(
+      @RequestBody ReCommentDto reCommentDto
+  ) {
+    recommentService.createRecomment(
+        reCommentDto.getContent(),
+        reCommentDto.getCommentId(),
+        reCommentDto.getUserId(),
+        reCommentDto.getPostId()
+    );
+
+    return "ok";
+  }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -40,6 +40,13 @@ public class Recomment {
     this.commentDate = commentDate;
   }
 
+  public Recomment(String content, Long commentId, Long userId, Long postId) {
+    this.content = content;
+    this.commentId = commentId;
+    this.userId = userId;
+    this.postId = postId;
+  }
+
   public Long getId() {
     return id;
   }

--- a/src/main/java/com/junstudio/kickoff/services/RecommentService.java
+++ b/src/main/java/com/junstudio/kickoff/services/RecommentService.java
@@ -23,4 +23,10 @@ public class RecommentService {
   public List<Recomment> findReComment(Long postId) {
     return recommentRepository.findAllByPostId(postId);
   }
+
+  public void createRecomment(String content, Long commentId, Long userId, Long postId) {
+    Recomment recomment = new Recomment(content, commentId, userId, postId);
+
+    recommentRepository.save(recomment);
+  }
 }

--- a/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
@@ -60,4 +60,18 @@ CommentControllerTest {
                 "}"))
         .andExpect(status().isCreated());
   }
+
+  @Test
+  void writeRecomment() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/recomment")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{" +
+                "\"content\":\"recomment\"," +
+                "\"commentId\":\"1\"," +
+                "\"userId\":\"3\"," +
+                "\"postId\":\"1\"" +
+                "}"))
+        .andExpect(status().isCreated());
+  }
 }

--- a/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/RecommentServiceTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class RecommentServiceTest {
   @MockBean
@@ -51,5 +52,18 @@ class RecommentServiceTest {
     List<Recomment> recomments = recommentService.findReComment(any(Long.class));
 
     assertThat(recomments).hasSize(1);
+  }
+
+  @Test
+  void createRecomment() {
+    Recomment recomment = mock(Recomment.class);
+
+    recommentService.createRecomment(
+        recomment.getContent(),
+        recomment.getCommentId(),
+        recomment.getUserId(),
+        recomment.getPostId());
+
+    verify(recommentRepository).save(any(Recomment.class));
   }
 }


### PR DESCRIPTION
- REST API POST/recomment
- 대댓글 내용, 대댓글을 단 댓글의 아이디, 대댓글을 쓴 유저 아이디, 대댓글을 단 게시글의 아이디를 받아 recomment객체를 생성해 저장