### PR TITLE
게시글 페이지네이션 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
@@ -8,6 +8,9 @@ import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.services.CreatePostService;
 import com.junstudio.kickoff.services.GetPostService;
 import com.junstudio.kickoff.utils.S3Uploader;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,16 +39,17 @@ public class PostsController {
 
     @GetMapping("/posts")
     public PostsDto posts(
-//      @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+      @PageableDefault(sort = "id", direction = Sort.Direction.ASC, value = 2) Pageable pageable
     ) {
-        return getPostService.posts();
+        return getPostService.posts(pageable);
     }
 
     @GetMapping("/category/{categoryId}")
     public PostsDto categoryPosts(
-        @PathVariable Long categoryId
+        @PathVariable Long categoryId,
+        @PageableDefault(sort = "id", direction = Sort.Direction.ASC, value = 2) Pageable pageable
     ) {
-        return getPostService.findCategoryPosts(categoryId);
+        return getPostService.findCategoryPosts(categoryId, pageable);
     }
 
     @GetMapping("/posts/{id}")

--- a/src/main/java/com/junstudio/kickoff/dtos/PageDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PageDto.java
@@ -1,0 +1,48 @@
+package com.junstudio.kickoff.dtos;
+
+public class PageDto {
+    private int startPage;
+
+    private int lastPage;
+
+    private int currentPageNumber;
+
+    private int currentLastPage;
+
+    private final Long totalPageNumber;
+
+    public PageDto(Long totalPageNumber) {
+        this.totalPageNumber = totalPageNumber;
+    }
+
+    public PageDto(int currentPageNumber, Long totalPageNumber) {
+        this.currentPageNumber = currentPageNumber;
+        this.totalPageNumber = totalPageNumber;
+        this.lastPage = (int) (Math.ceil(currentPageNumber / 10.0) * 10);
+        this.currentLastPage = (int) Math.ceil(totalPageNumber * 1.0 / 2);
+        this.startPage = lastPage - 9;
+    }
+
+    public int getStartPage() {
+        return startPage;
+    }
+
+    public int getLastPage() {
+        if(this.lastPage > currentLastPage) {
+            this.lastPage = currentLastPage;
+        }
+        return lastPage;
+    }
+
+    public Long getTotalPageNumber() {
+        return totalPageNumber;
+    }
+
+    public int getCurrentLastPage() {
+        return currentLastPage;
+    }
+
+    public int getCurrentPageNumber() {
+        return currentPageNumber;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
@@ -4,13 +4,22 @@ import java.util.List;
 
 public class PostsDto {
     private final List<PostDto> posts;
-
+    private PageDto page;
 
     public PostsDto(List<PostDto> posts) {
         this.posts = posts;
     }
 
+    public PostsDto(List<PostDto> posts, PageDto page) {
+        this.posts = posts;
+        this.page = page;
+    }
+
     public List<PostDto> getPosts() {
         return posts;
+    }
+
+    public PageDto getPage() {
+        return page;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
@@ -1,10 +1,12 @@
 package com.junstudio.kickoff.repositories;
 
 import com.junstudio.kickoff.models.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByCategoryId(Long categoryId);
+    Page<Post> findAllByCategoryId(Long categoryId, Pageable pageable);
+
+    Page<Post> findAll(Pageable pageable);
 }

--- a/src/main/java/com/junstudio/kickoff/services/GetPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetPostService.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.dtos.PageDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.PostsDto;
@@ -9,6 +10,7 @@ import com.junstudio.kickoff.models.Category;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.repositories.CategoryRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -21,18 +23,20 @@ public class GetPostService {
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
 
-    public GetPostService(PostRepository postRepository, CategoryRepository categoryRepository) {
+    public GetPostService(PostRepository postRepository,
+                          CategoryRepository categoryRepository) {
         this.postRepository = postRepository;
         this.categoryRepository = categoryRepository;
     }
 
-    public PostsDto posts() {
-//    Page<PostDto> post = postRepository.findAll(pageable);
-        List<PostDto> posts = postRepository.findAll()
-            .stream().map(Post::toDto)
-            .collect(Collectors.toList());
+    public PostsDto posts(Pageable pageable) {
+    List<PostDto> posts = postRepository.findAll(pageable)
+        .stream().map(Post::toDto)
+        .collect(Collectors.toList());
 
-        return new PostsDto(posts);
+        return new PostsDto(posts,
+            new PageDto(postRepository.findAll(pageable).getNumber() + 1,
+                postRepository.findAll(pageable).getTotalElements()));
     }
 
     public PostDetailDto findPost(Long postId) {
@@ -46,11 +50,16 @@ public class GetPostService {
         return post.toDetailDto(category);
     }
 
-    public PostsDto findCategoryPosts(Long categoryId) {
-        List<PostDto> categoryPosts = postRepository.findAllByCategoryId(categoryId)
+    public PostsDto findCategoryPosts(Long categoryId, Pageable pageable) {
+        List<PostDto> categoryPosts =
+            postRepository.findAllByCategoryId(categoryId, pageable)
             .stream().map(Post::toDto)
             .collect(Collectors.toList());
-        return new PostsDto(categoryPosts);
+
+        System.out.println();
+        return new PostsDto(categoryPosts,
+            new PageDto(postRepository.findAllByCategoryId(categoryId, pageable).getNumber() + 1,
+                postRepository.findAllByCategoryId(categoryId, pageable).getTotalElements()));
     }
 }
 

--- a/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,7 +57,7 @@ class PostsControllerTest {
 
     @Test
     void posts() throws Exception {
-        given(getPostService.posts()).willReturn(new PostsDto(
+        given(getPostService.posts(any(Pageable.class))).willReturn(new PostsDto(
             List.of(new PostDto(post.id(), post.postInformation(), post.categoryId(),
                 post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl()))));
 
@@ -69,8 +70,16 @@ class PostsControllerTest {
 
     @Test
     void categoryPosts() throws Exception {
+        given(getPostService.findCategoryPosts(any(Long.class), any(Pageable.class)))
+            .willReturn(new PostsDto(
+                List.of(new PostDto(post.id(), post.postInformation(), post.categoryId(),
+                    post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl()))));
+
         mockMvc.perform(MockMvcRequestBuilders.get("/category/1"))
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                containsString("content\":\"Son is the first Asian to score EPL")
+            ));
     }
 
     @Test

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -10,8 +10,14 @@ import com.junstudio.kickoff.repositories.CategoryRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +33,9 @@ class GetPostServiceTest {
 
     GetPostService getPostService;
 
+    @SpyBean
+    private Pageable pageable;
+
     @BeforeEach
     void setup() {
         postRepository = mock(PostRepository.class);
@@ -39,11 +48,18 @@ class GetPostServiceTest {
     void posts() {
         Post post = Post.fake();
 
-        given(postRepository.findAll()).willReturn(List.of(post));
+        pageable = PageRequest.of(1, 10);
 
-        PostsDto posts = getPostService.posts();
+        List<Post> posts = new ArrayList<>();
+        posts.add(post);
 
-        assertThat(posts.getPosts()).hasSize(1);
+        Page<Post> page = new PageImpl<>(posts);
+
+        given(postRepository.findAll(Pageable.ofSize(1))).willReturn(page);
+
+        PostsDto postsDto = getPostService.posts(Pageable.ofSize(1));
+
+        assertThat(postsDto.getPosts()).hasSize(1);
     }
 
     @Test
@@ -66,10 +82,15 @@ class GetPostServiceTest {
     void findCategoryPosts() {
         Post post = Post.fake();
 
-        given(postRepository.findAllByCategoryId(any())).willReturn(List.of(post));
+        List<Post> posts = new ArrayList<>();
+        posts.add(post);
 
-        PostsDto posts = getPostService.findCategoryPosts(post.categoryId());
+        Page<Post> page = new PageImpl<>(posts);
 
-        assertThat(posts.getPosts()).hasSize(1);
+        given(postRepository.findAllByCategoryId(any(), any())).willReturn(page);
+
+        PostsDto postsDto = getPostService.findCategoryPosts(any(), any());
+
+        assertThat(postsDto.getPosts()).hasSize(1);
     }
 }


### PR DESCRIPTION
- PageDto 생성
- 다음 페이지 이동, 이전 페이지 이동을 위한 현재 페이지에서 마지막 페이지 수와 전체 페이지에서 마지막 페이지 수 생성
- 현재 페이지 번호, 전체 페이지 번호, 시작 페이지 번호 생성
- 페이지가 5까지 밖에 존재하지 않는데 10페이지 버튼이 생기는걸 방지하기 위한 로직 구현