### PR TITLE
프론트엔드에서 불필요한 api호출을 제거하기 위해 모든 게시글 찾을때 게시글의 다른 정보도 한번에 보내주도록 리팩터링

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.controllers;
 
+import com.junstudio.kickoff.dtos.CreatePostsDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostWriteDto;
 import com.junstudio.kickoff.dtos.PostWrittenDto;
@@ -38,8 +39,8 @@ public class PostsController {
     }
 
     @GetMapping("/posts")
-    public PostsDto posts(
-      @PageableDefault(sort = "id", direction = Sort.Direction.ASC, value = 2) Pageable pageable
+    public CreatePostsDto posts(
+      @PageableDefault(sort = "id", size = 2) Pageable pageable
     ) {
         return getPostService.posts(pageable);
     }

--- a/src/main/java/com/junstudio/kickoff/dtos/CreatePostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/CreatePostsDto.java
@@ -1,0 +1,19 @@
+package com.junstudio.kickoff.dtos;
+
+public class CreatePostsDto {
+    private final PostsDto posts;
+    private final PostPageDto postPageDto;
+
+    public CreatePostsDto(PostsDto posts, PostPageDto postPageDto) {
+        this.posts = posts.toDto();
+        this.postPageDto = postPageDto;
+    }
+
+    public PostsDto getPosts() {
+        return posts;
+    }
+
+    public PostPageDto getPostPageDto() {
+        return postPageDto;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
@@ -56,4 +56,9 @@ public class PostDto {
     public String getImageUrl() {
         return imageUrl;
     }
+
+    public PostDto toDto() {
+        return new PostDto(id, new PostInformation(postInformation.getTitle(), postInformation.getContent()),
+            categoryId, userId, hit, createdAt, imageUrl);
+    }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/PostPageDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostPageDto.java
@@ -1,13 +1,13 @@
 package com.junstudio.kickoff.dtos;
 
 public class PostPageDto {
-    private int startPage;
+    private final int startPage;
 
     private int lastPage;
 
-    private int currentPageNumber;
+    private final int currentPageNumber;
 
-    private int currentLastPage;
+    private final int currentLastPage;
 
     private final Long totalPageNumber;
 
@@ -24,7 +24,7 @@ public class PostPageDto {
     }
 
     public int getLastPage() {
-        if(this.lastPage > currentLastPage) {
+        if (this.lastPage > currentLastPage) {
             this.lastPage = currentLastPage;
         }
         return lastPage;

--- a/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
@@ -3,23 +3,67 @@ package com.junstudio.kickoff.dtos;
 import java.util.List;
 
 public class PostsDto {
-    private final List<PostDto> posts;
     private PostPageDto page;
+    private List<PostDto> categoryPosts;
+    private List<PostDto> posts;
+    private List<CommentDto> comments;
+    private List<ReCommentDto> reComments;
+    private List<LikeDto> likes;
+    private List<CategoryDto> categories;
+    private List<UserDto> users;
 
-    public PostsDto(List<PostDto> posts) {
-        this.posts = posts;
+    public PostsDto(List<PostDto> categoryPosts, PostPageDto page) {
+        this.categoryPosts = categoryPosts;
+        this.page = page;
     }
 
-    public PostsDto(List<PostDto> posts, PostPageDto page) {
+    public PostsDto(List<PostDto> posts,
+                    List<CommentDto> comments,
+                    List<ReCommentDto> reComments,
+                    List<LikeDto> likes,
+                    List<CategoryDto> categories,
+                    List<UserDto> users) {
         this.posts = posts;
-        this.page = page;
+        this.comments = comments;
+        this.reComments = reComments;
+        this.likes = likes;
+        this.categories = categories;
+        this.users = users;
+    }
+
+    public PostPageDto getPage() {
+        return page;
+    }
+
+    public List<PostDto> getCategoryPosts() {
+        return categoryPosts;
     }
 
     public List<PostDto> getPosts() {
         return posts;
     }
 
-    public PostPageDto getPage() {
-        return page;
+    public List<CommentDto> getComments() {
+        return comments;
+    }
+
+    public List<ReCommentDto> getReComments() {
+        return reComments;
+    }
+
+    public List<LikeDto> getLikes() {
+        return likes;
+    }
+
+    public List<CategoryDto> getCategories() {
+        return categories;
+    }
+
+    public List<UserDto> getUsers() {
+        return users;
+    }
+
+    public PostsDto toDto() {
+        return new PostsDto(posts, comments, reComments, likes, categories, users);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Comment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Comment.java
@@ -68,4 +68,8 @@ public class Comment {
         return new CommentDto(id, content, userId, postId,
             commentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
     }
+
+    public static Comment fake() {
+        return new Comment(1L, "reply", 1L, 1L, LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Like.java
+++ b/src/main/java/com/junstudio/kickoff/models/Like.java
@@ -53,4 +53,8 @@ public class Like {
     public LikeDto toLikeDto() {
         return new LikeDto(id, postId, userId);
     }
+
+    public static Like fake() {
+        return new Like(1L, 1L, 1L);
+    }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -48,6 +48,7 @@ public class Recomment {
         this.postId = postId;
     }
 
+
     public Long getId() {
         return id;
     }
@@ -75,5 +76,9 @@ public class Recomment {
     public ReCommentDto toDto() {
         return new ReCommentDto(id, content, commentId, postId, userId,
             commentDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+    }
+
+    public static Recomment fake() {
+        return new Recomment(1L, 1L, "대댓글", 1L, 1L, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/junstudio/kickoff/services/GetPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetPostService.java
@@ -1,15 +1,29 @@
 package com.junstudio.kickoff.services;
 
-import com.junstudio.kickoff.dtos.PostPageDto;
+import com.junstudio.kickoff.dtos.CategoryDto;
+import com.junstudio.kickoff.dtos.CommentDto;
+import com.junstudio.kickoff.dtos.CreatePostsDto;
+import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
+import com.junstudio.kickoff.dtos.PostPageDto;
 import com.junstudio.kickoff.dtos.PostsDto;
+import com.junstudio.kickoff.dtos.ReCommentDto;
+import com.junstudio.kickoff.dtos.UserDto;
 import com.junstudio.kickoff.exceptions.CategoryNotFound;
 import com.junstudio.kickoff.exceptions.PostNotFound;
 import com.junstudio.kickoff.models.Category;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.CategoryRepository;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.LikeRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -22,19 +36,41 @@ import java.util.stream.Collectors;
 public class GetPostService {
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
 
     public GetPostService(PostRepository postRepository,
-                          CategoryRepository categoryRepository) {
+                          CategoryRepository categoryRepository,
+                          CommentRepository commentRepository,
+                          RecommentRepository recommentRepository,
+                          LikeRepository likeRepository,
+                          UserRepository userRepository) {
         this.postRepository = postRepository;
         this.categoryRepository = categoryRepository;
+        this.commentRepository = commentRepository;
+        this.recommentRepository = recommentRepository;
+        this.likeRepository = likeRepository;
+        this.userRepository = userRepository;
     }
 
-    public PostsDto posts(Pageable pageable) {
-    List<PostDto> posts = postRepository.findAll(pageable)
-        .stream().map(Post::toDto)
-        .collect(Collectors.toList());
+    public CreatePostsDto posts(Pageable pageable) {
+        List<PostDto> posts = getPostDtos(pageable);
 
-        return new PostsDto(posts,
+        List<CommentDto> comments = getCommentDtos();
+
+        List<ReCommentDto> reComments = getReCommentDtos();
+
+        List<LikeDto> likes = getLikeDtos();
+
+        List<CategoryDto> categories = getCategoryDtoList();
+
+        List<UserDto> users = getUserDtos();
+
+        PostsDto postsDto = new PostsDto(posts, comments, reComments, likes, categories, users);
+
+        return new CreatePostsDto(postsDto,
             new PostPageDto(postRepository.findAll(pageable).getNumber() + 1,
                 postRepository.findAll(pageable).getTotalElements()));
     }
@@ -53,13 +89,48 @@ public class GetPostService {
     public PostsDto findCategoryPosts(Long categoryId, Pageable pageable) {
         List<PostDto> categoryPosts =
             postRepository.findAllByCategoryId(categoryId, pageable)
-            .stream().map(Post::toDto)
-            .collect(Collectors.toList());
+                .stream().map(Post::toDto)
+                .collect(Collectors.toList());
 
-        System.out.println();
         return new PostsDto(categoryPosts,
             new PostPageDto(postRepository.findAllByCategoryId(categoryId, pageable).getNumber() + 1,
                 postRepository.findAllByCategoryId(categoryId, pageable).getTotalElements()));
+    }
+
+    private List<PostDto> getPostDtos(Pageable pageable) {
+        return postRepository.findAll(pageable)
+            .stream().map(Post::toDto)
+            .collect(Collectors.toList());
+    }
+
+    private List<CommentDto> getCommentDtos() {
+        return commentRepository.findAll()
+            .stream().map(Comment::toDto)
+            .collect(Collectors.toList());
+    }
+
+    private List<ReCommentDto> getReCommentDtos() {
+        return recommentRepository.findAll()
+            .stream().map(Recomment::toDto)
+            .collect(Collectors.toList());
+    }
+
+    private List<LikeDto> getLikeDtos() {
+        return likeRepository.findAll()
+            .stream().map(Like::toDto)
+            .collect(Collectors.toList());
+    }
+
+    private List<CategoryDto> getCategoryDtoList() {
+        return categoryRepository.findAll()
+            .stream().map(Category::toDto)
+            .collect(Collectors.toList());
+    }
+
+    private List<UserDto> getUserDtos() {
+        return userRepository.findAll()
+            .stream().map(User::toDto)
+            .collect(Collectors.toList());
     }
 }
 

--- a/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
@@ -1,11 +1,20 @@
 package com.junstudio.kickoff.controllers;
 
+import com.junstudio.kickoff.dtos.CategoryDto;
+import com.junstudio.kickoff.dtos.CommentDto;
+import com.junstudio.kickoff.dtos.CreatePostsDto;
+import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
+import com.junstudio.kickoff.dtos.PostPageDto;
 import com.junstudio.kickoff.dtos.PostsDto;
+import com.junstudio.kickoff.dtos.ReCommentDto;
 import com.junstudio.kickoff.models.Category;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
+import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.services.CreatePostService;
 import com.junstudio.kickoff.services.GetPostService;
 import com.junstudio.kickoff.utils.S3Uploader;
@@ -46,6 +55,12 @@ class PostsControllerTest {
 
     private Post post;
 
+    private Comment comment;
+
+    private Recomment recomment;
+
+    private Like like;
+
     private Category category;
 
     @BeforeEach
@@ -53,13 +68,32 @@ class PostsControllerTest {
         category = new Category(1L, "EPL", null);
 
         post = Post.fake();
+        comment = Comment.fake();
+        recomment = Recomment.fake();
+        like = Like.fake();
     }
 
     @Test
     void posts() throws Exception {
-        given(getPostService.posts(any(Pageable.class))).willReturn(new PostsDto(
-            List.of(new PostDto(post.id(), post.postInformation(), post.categoryId(),
-                post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl()))));
+        PostDto postDto = new PostDto(post.id(), post.postInformation(),
+            post.categoryId(), post.userId(), post.hit(),
+            post.createdAt().toString(), post.imageUrl());
+
+        CommentDto commentDto = new CommentDto(comment.id(), comment.content(),
+            comment.userId(), comment.postId(), comment.commentDate().toString());
+
+        ReCommentDto recommentDto =
+            new ReCommentDto(recomment.getCommentId(), recomment.getContent(),
+                recomment.getCommentId(), recomment.getPostId(),
+                recomment.getPostId(), recomment.getCommentDate().toString());
+
+        LikeDto likeDto = new LikeDto(like.id(), like.postId(), like.userId());
+
+        CategoryDto categoryDto = new CategoryDto(category.id(), category.name(), category.getParentId());
+
+        given(getPostService.posts(any(Pageable.class))).willReturn(new CreatePostsDto(
+            new PostsDto(List.of(postDto), List.of(commentDto), List.of(recommentDto),
+                List.of(likeDto), List.of(categoryDto), any()), new PostPageDto(1, 1L)));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/posts"))
             .andExpect(status().isOk())
@@ -70,10 +104,11 @@ class PostsControllerTest {
 
     @Test
     void categoryPosts() throws Exception {
-        given(getPostService.findCategoryPosts(any(Long.class), any(Pageable.class)))
-            .willReturn(new PostsDto(
-                List.of(new PostDto(post.id(), post.postInformation(), post.categoryId(),
-                    post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl()))));
+        PostDto postDto = new PostDto(post.id(), post.postInformation(),
+            post.categoryId(), post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl());
+
+        given(getPostService.findCategoryPosts(any(), any()))
+            .willReturn(new PostsDto(List.of(postDto), new PostPageDto(1, 1L)));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/category/1"))
             .andExpect(status().isOk())

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.dtos.CreatePostsDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.models.Category;
@@ -7,13 +8,15 @@ import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
 import com.junstudio.kickoff.models.UserId;
 import com.junstudio.kickoff.repositories.CategoryRepository;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.LikeRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
@@ -30,6 +33,10 @@ import static org.mockito.Mockito.verify;
 class GetPostServiceTest {
     PostRepository postRepository;
     CategoryRepository categoryRepository;
+    CommentRepository commentRepository;
+    RecommentRepository recommentRepository;
+    LikeRepository likeRepository;
+    UserRepository userRepository;
 
     GetPostService getPostService;
 
@@ -37,8 +44,17 @@ class GetPostServiceTest {
     void setup() {
         postRepository = mock(PostRepository.class);
         categoryRepository = mock(CategoryRepository.class);
+        commentRepository = mock(CommentRepository.class);
+        recommentRepository = mock(RecommentRepository.class);
+        likeRepository = mock(LikeRepository.class);
+        userRepository = mock(UserRepository.class);
 
-        getPostService = new GetPostService(postRepository, categoryRepository);
+        getPostService = new GetPostService(postRepository,
+            categoryRepository,
+            commentRepository,
+            recommentRepository,
+            likeRepository,
+            userRepository);
     }
 
     @Test
@@ -52,9 +68,9 @@ class GetPostServiceTest {
 
         given(postRepository.findAll(Pageable.ofSize(1))).willReturn(page);
 
-        PostsDto postsDto = getPostService.posts(Pageable.ofSize(1));
+        CreatePostsDto createPostsDto = getPostService.posts(Pageable.ofSize(1));
 
-        assertThat(postsDto.getPosts()).hasSize(1);
+        assertThat(createPostsDto).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
- GetPostService 수정 -> posts, comment, recomments, likes, categories, users 정보 한번에 보내줌