### PR TITLE
게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
@@ -7,6 +7,7 @@ import com.junstudio.kickoff.dtos.PostWrittenDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.services.CreatePostService;
+import com.junstudio.kickoff.services.DeletePostService;
 import com.junstudio.kickoff.services.GetPostService;
 import com.junstudio.kickoff.services.PatchPostService;
 import com.junstudio.kickoff.utils.S3Uploader;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,15 +36,18 @@ public class PostsController {
     private final GetPostService getPostService;
     private final CreatePostService createPostService;
     private final PatchPostService patchPostService;
+    private final DeletePostService deletePostService;
 
     public PostsController(S3Uploader s3Uploader,
                            GetPostService getPostService,
                            CreatePostService createPostService,
-                           PatchPostService patchPostService) {
+                           PatchPostService patchPostService,
+                           DeletePostService deletePostService) {
         this.s3Uploader = s3Uploader;
         this.getPostService = getPostService;
         this.createPostService = createPostService;
         this.patchPostService = patchPostService;
+        this.deletePostService = deletePostService;
     }
 
     @GetMapping("/posts")
@@ -89,6 +94,14 @@ public class PostsController {
         @PathVariable Long postId
     ) {
         patchPostService.patch(postWriteDto, postId);
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+        @PathVariable Long postId
+    ) {
+        deletePostService.delete(postId);
     }
 
     @PostMapping("/upload")

--- a/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+
+    void deleteAllById(Long postId);
+
+    Comment getReferenceByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
@@ -10,4 +10,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
   Optional<Like> findByPostId(Long postId);
 
   List<Like> findAllByPostId(Long postId);
+
+    void deleteAllById(Long postId);
+
+  Like getReferenceByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
@@ -7,4 +7,8 @@ import java.util.List;
 
 public interface RecommentRepository extends JpaRepository<Recomment, Long> {
   List<Recomment> findAllByPostId(Long postId);
+
+    void deleteAllById(Long postId);
+
+  Recomment getReferenceByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
@@ -1,0 +1,44 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Like;
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.LikeRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class DeletePostService {
+    private final PostRepository postRepository;
+    private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+
+    public DeletePostService(PostRepository postRepository,
+                             LikeRepository likeRepository,
+                             CommentRepository commentRepository,
+                             RecommentRepository recommentRepository) {
+        this.postRepository = postRepository;
+        this.likeRepository = likeRepository;
+        this.commentRepository = commentRepository;
+        this.recommentRepository = recommentRepository;
+    }
+
+    public void delete(Long postId) {
+        Post post = postRepository.getReferenceById(postId);
+        Like like = likeRepository.getReferenceByPostId(postId);
+        Comment comment = commentRepository.getReferenceByPostId(postId);
+        Recomment recomment = recommentRepository.getReferenceByPostId(postId);
+
+        likeRepository.deleteAllById(like.id());
+        recommentRepository.deleteAllById(recomment.getId());
+        commentRepository.deleteAllById(comment.id());
+        postRepository.delete(post);
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
@@ -7,7 +7,6 @@ import com.junstudio.kickoff.dtos.LikeDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.PostPageDto;
-import com.junstudio.kickoff.dtos.PostWriteDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.dtos.ReCommentDto;
 import com.junstudio.kickoff.models.Category;
@@ -16,8 +15,8 @@ import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
 import com.junstudio.kickoff.models.Recomment;
-import com.junstudio.kickoff.models.UserId;
 import com.junstudio.kickoff.services.CreatePostService;
+import com.junstudio.kickoff.services.DeletePostService;
 import com.junstudio.kickoff.services.GetPostService;
 import com.junstudio.kickoff.services.PatchPostService;
 import com.junstudio.kickoff.utils.S3Uploader;
@@ -32,12 +31,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -57,6 +54,9 @@ class PostsControllerTest {
 
     @MockBean
     private PatchPostService patchPostService;
+
+    @MockBean
+    private DeletePostService deletePostService;
 
     @MockBean
     private S3Uploader s3Uploader;
@@ -172,5 +172,13 @@ class PostsControllerTest {
                     "\"categoryId\":\"1\"" +
                     "}"))
             .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void delete() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/posts/1"))
+            .andExpect(status().isNoContent());
+
+        verify(deletePostService).delete(post.id());
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/DeletePostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/DeletePostServiceTest.java
@@ -1,0 +1,32 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.repositories.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class DeletePostServiceTest {
+    @MockBean
+    private PostRepository postRepository;
+
+    @Test
+    void delete() {
+        Post post = spy(Post.fake());
+
+        postRepository = mock(PostRepository.class);
+
+        DeletePostService deletePostService = mock(DeletePostService.class);
+
+        given(postRepository.getReferenceById(post.id())).willReturn(post);
+
+        deletePostService.delete(any(Long.class));
+
+        verify(deletePostService).delete(any(Long.class));
+    }
+}


### PR DESCRIPTION
- REST API DELETE /posts/{postId}
- 게시글 삭제할 시 게시글에 있는 댓글, 대댓글, 좋아요까지 같이 삭제