### PR TITLE
게시글 삭제 기능 수정

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostsController.java
@@ -52,7 +52,7 @@ public class PostsController {
 
     @GetMapping("/posts")
     public CreatePostsDto posts(
-      @PageableDefault(sort = "id", size = 2) Pageable pageable
+      @PageableDefault(sort = "id", direction = Sort.Direction.DESC, size = 2) Pageable pageable
     ) {
         return getPostService.posts(pageable);
     }
@@ -60,7 +60,7 @@ public class PostsController {
     @GetMapping("/category/{categoryId}")
     public PostsDto categoryPosts(
         @PathVariable Long categoryId,
-        @PageableDefault(sort = "id", direction = Sort.Direction.ASC, value = 2) Pageable pageable
+        @PageableDefault(sort = "id", direction = Sort.Direction.DESC, value = 2) Pageable pageable
     ) {
         return getPostService.findCategoryPosts(categoryId, pageable);
     }

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDetailDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDetailDto.java
@@ -12,16 +12,19 @@ public class PostDetailDto {
 
     private final Long hit;
 
+    private final Long likeNumber;
+
     private final String createdAt;
 
     private final String imageUrl;
 
-    public PostDetailDto(Long id, PostInformation postInformation, Long hit,
+    public PostDetailDto(Long id, PostInformation postInformation, Long hit, Long likeNumber,
                          Category category, String createdAt, String imageUrl) {
         this.id = id;
         this.postInformation = postInformation;
         this.category = category.toDto();
         this.hit = hit;
+        this.likeNumber = likeNumber;
         this.createdAt = createdAt;
         this.imageUrl = imageUrl;
     }
@@ -40,6 +43,10 @@ public class PostDetailDto {
 
     public Long getHit() {
         return hit;
+    }
+
+    public Long getLikeNumber() {
+        return likeNumber;
     }
 
     public String getCreatedAt() {

--- a/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostDto.java
@@ -14,17 +14,20 @@ public class PostDto {
 
     private final Long hit;
 
+    private final Long likeNumber;
+
     private final String createdAt;
 
     private final String imageUrl;
 
     public PostDto(Long id, PostInformation postInformation, Long categoryId,
-                   UserId userId, Long hit, String createdAt, String imageUrl) {
+                   UserId userId, Long hit, Long likeNumber, String createdAt, String imageUrl) {
         this.id = id;
         this.postInformation = postInformation.toDto();
         this.categoryId = categoryId;
         this.userId = userId;
         this.hit = hit;
+        this.likeNumber = likeNumber;
         this.createdAt = createdAt;
         this.imageUrl = imageUrl;
     }
@@ -49,6 +52,10 @@ public class PostDto {
         return hit;
     }
 
+    public Long getLikeNumber() {
+        return likeNumber;
+    }
+
     public String getCreatedAt() {
         return createdAt;
     }
@@ -58,7 +65,8 @@ public class PostDto {
     }
 
     public PostDto toDto() {
-        return new PostDto(id, new PostInformation(postInformation.getTitle(), postInformation.getContent()),
-            categoryId, userId, hit, createdAt, imageUrl);
+        return new PostDto(id, new PostInformation(postInformation.getTitle(),
+            postInformation.getContent()), categoryId, userId, hit, likeNumber,
+            createdAt, imageUrl);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/exceptions/LikeNotFound.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/LikeNotFound.java
@@ -1,0 +1,7 @@
+package com.junstudio.kickoff.exceptions;
+
+public class LikeNotFound extends RuntimeException {
+    public LikeNotFound() {
+        super("좋아요가 없습니다.");
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/Post.java
+++ b/src/main/java/com/junstudio/kickoff/models/Post.java
@@ -30,6 +30,8 @@ public class Post {
 
     private Long hit;
 
+    private Long likeNumber;
+
     @Column(name = "imageUrl", length = 2048)
     private String imageUrl;
 
@@ -41,13 +43,14 @@ public class Post {
 
     public Post(Long id, UserId userId, Long categoryId,
                 PostInformation postInformation,
-                Long hit, String imageUrl,
+                Long hit, Long likeNumber, String imageUrl,
                 LocalDateTime createdAt) {
         this.id = id;
         this.userId = userId;
         this.categoryId = categoryId;
         this.postInformation = postInformation;
         this.hit = hit;
+        this.likeNumber = likeNumber;
         this.imageUrl = imageUrl;
         this.createdAt = createdAt;
     }
@@ -59,6 +62,7 @@ public class Post {
         this.imageUrl = imageUrl;
         this.userId = new UserId(userId);
         this.categoryId = categoryId;
+        this.likeNumber = 0L;
     }
 
     public Long id() {
@@ -81,6 +85,10 @@ public class Post {
         return hit;
     }
 
+    public Long likeNumber() {
+        return likeNumber;
+    }
+
     public String imageUrl() {
         return imageUrl;
     }
@@ -90,7 +98,7 @@ public class Post {
     }
 
     public PostDto toDto() {
-        return new PostDto(id, postInformation, categoryId, userId, hit,
+        return new PostDto(id, postInformation, categoryId, userId, hit, likeNumber,
             createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), imageUrl);
     }
 
@@ -103,7 +111,7 @@ public class Post {
     }
 
     public PostDetailDto toDetailDto(Category category) {
-        return new PostDetailDto(id, postInformation, hit, category,
+        return new PostDetailDto(id, postInformation, hit, likeNumber, category,
             createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), imageUrl);
     }
 
@@ -111,12 +119,20 @@ public class Post {
         return new Post(1L, new UserId(1L), 1L,
             new PostInformation("Son is EPL King",
                 "Son is the first Asian to score EPL"),
-            3L, "imageUrl", LocalDateTime.now());
+            3L, 1L, "imageUrl", LocalDateTime.now());
     }
 
     public void patch(String title, String content, Long categoryId, String imageUrl) {
         this.postInformation = new PostInformation(title, content);
         this.categoryId = categoryId;
         this.imageUrl = imageUrl;
+    }
+
+    public void addLike() {
+        this.likeNumber += 1L;
+    }
+
+    public void minusLike() {
+        this.likeNumber -= 1L;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -48,12 +48,11 @@ public class Recomment {
         this.postId = postId;
     }
 
-
-    public Long getId() {
+    public Long id() {
         return id;
     }
 
-    public Long getCommentId() {
+    public Long commentId() {
         return commentId;
     }
 

--- a/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/CommentRepository.java
@@ -5,10 +5,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
 
     void deleteAllById(Long postId);
 
     Comment getReferenceByPostId(Long postId);
+
+    boolean existsByPostId(Long postId);
+
+    List<Comment> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
@@ -14,4 +14,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
   void deleteAllById(Long postId);
 
   Like getReferenceByPostId(Long postId);
+
+    boolean existsByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/RecommentRepository.java
@@ -13,4 +13,6 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
     Recomment getReferenceByPostId(Long postId);
 
     boolean existsByCommentId(Long commentId);
+
+    boolean existsByPostId(Long postId);
 }

--- a/src/main/java/com/junstudio/kickoff/services/CreateLikeService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CreateLikeService.java
@@ -37,12 +37,14 @@ public class CreateLikeService {
 
         if (!(foundLike.equals(like))) {
             if (Objects.equals(foundLike.userId(), userId)) {
+                post.minusLike();
                 likeRepository.deleteById(foundLike.id());
                 return;
             }
         }
 
         Like newLike = new Like(post.id(), user.id());
+        post.addLike();
         likeRepository.save(newLike);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.exceptions.LikeNotFound;
 import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
@@ -11,6 +12,7 @@ import com.junstudio.kickoff.repositories.RecommentRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -32,13 +34,31 @@ public class DeletePostService {
 
     public void delete(Long postId) {
         Post post = postRepository.getReferenceById(postId);
-        Like like = likeRepository.getReferenceByPostId(postId);
-        Comment comment = commentRepository.getReferenceByPostId(postId);
-        Recomment recomment = recommentRepository.getReferenceByPostId(postId);
 
-        likeRepository.deleteAllById(like.id());
-        recommentRepository.deleteAllById(recomment.getId());
-        commentRepository.deleteAllById(comment.id());
+        if(likeRepository.existsByPostId(postId)) {
+            List<Like> likes = likeRepository.findAllByPostId(postId);
+
+            for (int i = 0; i < likes.size(); i += 1) {
+                likeRepository.deleteAllById(likes.get(i).id());
+            }
+        }
+
+        if(commentRepository.existsByPostId(postId)) {
+            List<Comment> comments = commentRepository.findAllByPostId(postId);
+
+            for (int i = 0; i < comments.size(); i += 1) {
+                commentRepository.deleteAllById(comments.get(i).id());
+            }
+        }
+
+        if (recommentRepository.existsByPostId(postId)) {
+            List<Recomment> recomments = recommentRepository.findAllByPostId(postId);
+
+            for (int i = 0; i < recomments.size(); i += 1) {
+                recommentRepository.deleteAllById(recomments.get(i).id());
+            }
+        }
+
         postRepository.delete(post);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/services/DeleteRecommentService.java
+++ b/src/main/java/com/junstudio/kickoff/services/DeleteRecommentService.java
@@ -23,8 +23,11 @@ public class DeleteRecommentService {
     public void delete(Long recommentId) {
         Recomment recomment = recommentRepository.getReferenceById(recommentId);
 
-        if(commentRepository.getReferenceById(recomment.getCommentId()).isDeleted()) {
-            Comment comment = commentRepository.getReferenceById(recomment.getCommentId());
+        if(commentRepository.getReferenceById(
+            recomment.commentId())
+            .isDeleted()
+        ) {
+            Comment comment = commentRepository.getReferenceById(recomment.commentId());
 
             recommentRepository.delete(recomment);
 
@@ -33,7 +36,10 @@ public class DeleteRecommentService {
             }
         }
 
-        if(!commentRepository.getReferenceById(recomment.getCommentId()).isDeleted()) {
+        if(!commentRepository.getReferenceById(
+            recomment.commentId())
+            .isDeleted()
+        ) {
             recommentRepository.delete(recomment);
         }
     }

--- a/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostsControllerTest.java
@@ -84,15 +84,15 @@ class PostsControllerTest {
     @Test
     void posts() throws Exception {
         PostDto postDto = new PostDto(post.id(), post.postInformation(),
-            post.categoryId(), post.userId(), post.hit(),
+            post.categoryId(), post.userId(), post.hit(), post.likeNumber(),
             post.createdAt().toString(), post.imageUrl());
 
         CommentDto commentDto = new CommentDto(comment.id(), comment.content(),
             comment.userId(), comment.postId(), comment.isDeleted(), comment.commentDate().toString());
 
         ReCommentDto recommentDto =
-            new ReCommentDto(recomment.getCommentId(), recomment.getContent(),
-                recomment.getCommentId(), recomment.getPostId(),
+            new ReCommentDto(recomment.commentId(), recomment.getContent(),
+                recomment.commentId(), recomment.getPostId(),
                 recomment.getPostId(), recomment.getCommentDate().toString());
 
         LikeDto likeDto = new LikeDto(like.id(), like.postId(), like.userId());
@@ -113,7 +113,8 @@ class PostsControllerTest {
     @Test
     void categoryPosts() throws Exception {
         PostDto postDto = new PostDto(post.id(), post.postInformation(),
-            post.categoryId(), post.userId(), post.hit(), post.createdAt().toString(), post.imageUrl());
+            post.categoryId(), post.userId(), post.hit(), post.likeNumber(),
+            post.createdAt().toString(), post.imageUrl());
 
         given(getPostService.findCategoryPosts(any(), any()))
             .willReturn(new PostsDto(List.of(postDto), new PostPageDto(1, 1L)));
@@ -128,7 +129,7 @@ class PostsControllerTest {
     @Test
     void postDetail() throws Exception {
         given(getPostService.findPost(any(Long.class)))
-            .willReturn(new PostDetailDto(1L, new PostInformation("title", "content"), 1L,
+            .willReturn(new PostDetailDto(1L, new PostInformation("title", "content"), 1L, 1L,
                 category, "2022", "imageUrl"));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/posts/1"))

--- a/src/test/java/com/junstudio/kickoff/models/PostTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/PostTest.java
@@ -17,7 +17,7 @@ class PostTest {
 
         post = new Post(1L, new UserId(1L), 1L,
             new PostInformation("손흥민 득점왕 수상", "손흥민 아시아인 최초 EPL 득점왕"),
-            3L, "imageUrl", LocalDateTime.now());
+            3L, 1L, "imageUrl", LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/com/junstudio/kickoff/services/CreateRecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateRecommentServiceTest.java
@@ -30,7 +30,7 @@ class CreateRecommentServiceTest {
 
         createRecommentService.createRecomment(
             recomment.getContent(),
-            recomment.getCommentId(),
+            recomment.commentId(),
             recomment.getUserId(),
             recomment.getPostId());
 

--- a/src/test/java/com/junstudio/kickoff/services/DeleteRecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/DeleteRecommentServiceTest.java
@@ -38,24 +38,24 @@ class DeleteRecommentServiceTest {
 
     @Test
     void deleteOnlyRecomment() {
-        given(recommentRepository.getReferenceById(recomment.getId())).willReturn(recomment);
+        given(recommentRepository.getReferenceById(recomment.id())).willReturn(recomment);
 
-        given(commentRepository.getReferenceById(recomment.getCommentId())).willReturn(comment);
+        given(commentRepository.getReferenceById(recomment.commentId())).willReturn(comment);
 
-        deleteRecommentService.delete(recomment.getId());
+        deleteRecommentService.delete(recomment.id());
 
         verify(recommentRepository).delete(recomment);
     }
 
     @Test
     void deleteRecommentWithComment() {
-        given(recommentRepository.getReferenceById(recomment.getId())).willReturn(recomment);
+        given(recommentRepository.getReferenceById(recomment.id())).willReturn(recomment);
 
         comment.delete();
 
-        given(commentRepository.getReferenceById(recomment.getCommentId())).willReturn(comment);
+        given(commentRepository.getReferenceById(recomment.commentId())).willReturn(comment);
 
-        deleteRecommentService.delete(recomment.getId());
+        deleteRecommentService.delete(recomment.id());
 
         verify(recommentRepository).delete(recomment);
         verify(commentRepository).delete(comment);

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -78,7 +78,7 @@ class GetPostServiceTest {
     void findPost() {
         Post post = new Post(1L, new UserId(1L), 1L,
             new PostInformation("EPL start", "손흥민 아시아인 최초 EPL 득점왕"),
-            3L, "imageUrl", LocalDateTime.now());
+            3L, 1L, "imageUrl", LocalDateTime.now());
 
         given(postRepository.findById(any())).willReturn(Optional.of(post));
         given(categoryRepository.findById(any())).willReturn(Optional.of(new Category()));

--- a/src/test/java/com/junstudio/kickoff/services/PatchRecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PatchRecommentServiceTest.java
@@ -23,9 +23,9 @@ class PatchRecommentServiceTest {
         PatchRecommentService patchRecommentService
             = new PatchRecommentService(recommentRepository);
 
-        given(recommentRepository.getReferenceById(recomment.getId())).willReturn(recomment);
+        given(recommentRepository.getReferenceById(recomment.id())).willReturn(recomment);
 
-        patchRecommentService.patch(recomment.getId(), recomment.getContent());
+        patchRecommentService.patch(recomment.id(), recomment.getContent());
 
         verify(recomment).patch(recomment.getContent());
     }


### PR DESCRIPTION
- 게시글에 댓글 / 대댓글이 복수개일때 삭제 안되던 문제 해결
- 서비스에서 모든 댓글, 대댓글, 좋아요를 찾아서 리스트에 담아 반복문으로 모두 지워질떄까지 반복해서 제거