### PR TITLE
프로필 수정 기능 및 마이페이지에서 체크한 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/PostController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/PostController.java
@@ -3,6 +3,7 @@ package com.junstudio.kickoff.controllers;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostWriteDto;
 import com.junstudio.kickoff.dtos.PostWrittenDto;
+import com.junstudio.kickoff.dtos.SelectedPostsDto;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.services.CreatePostService;
 import com.junstudio.kickoff.services.DeletePostService;
@@ -23,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @CrossOrigin
@@ -82,6 +84,14 @@ public class PostController {
         @PathVariable Long postId
     ) {
         deletePostService.delete(postId);
+    }
+
+    @DeleteMapping("/posts")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteSelectedPost(
+        @RequestBody SelectedPostsDto selectedPostsDto
+    ) {
+        deletePostService.deletePosts(selectedPostsDto.postsId);
     }
 
     @PostMapping("/upload")

--- a/src/main/java/com/junstudio/kickoff/controllers/UserController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/UserController.java
@@ -3,12 +3,20 @@ package com.junstudio.kickoff.controllers;
 import com.junstudio.kickoff.dtos.UserDto;
 import com.junstudio.kickoff.dtos.UserInformationDto;
 import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.exceptions.PatchFailed;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.services.GetUserService;
+import com.junstudio.kickoff.services.PatchUserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -16,11 +24,15 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("users")
+@CrossOrigin
 public class UserController {
     private final GetUserService getUserService;
+    private final PatchUserService patchUserService;
 
-    public UserController(GetUserService getUserService) {
+    public UserController(GetUserService getUserService,
+                          PatchUserService patchUserService) {
         this.getUserService = getUserService;
+        this.patchUserService = patchUserService;
     }
 
     @GetMapping()
@@ -48,5 +60,20 @@ public class UserController {
         UsersDto usersDto = getUserService.findUser(userId, identification);
 
         return new UserInformationDto(usersDto);
+    }
+
+    @PatchMapping("{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(
+        @RequestBody UserDto userDto,
+        @PathVariable Long userId
+    ) {
+        patchUserService.patch(userId, userDto);
+    }
+
+    @ExceptionHandler(PatchFailed.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public PatchFailed patchFailed() {
+        return new PatchFailed();
     }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/BoardDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/BoardDto.java
@@ -1,6 +1,5 @@
 package com.junstudio.kickoff.dtos;
 
-import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardName;
 
 public class BoardDto {

--- a/src/main/java/com/junstudio/kickoff/dtos/SelectedPostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/SelectedPostsDto.java
@@ -1,0 +1,18 @@
+package com.junstudio.kickoff.dtos;
+
+import java.util.List;
+
+public class SelectedPostsDto {
+    public List<Long> postsId;
+
+    public SelectedPostsDto(List<Long> postsId) {
+        this.postsId = postsId;
+    }
+
+    public List<Long> getPostsId() {
+        return postsId;
+    }
+
+    public SelectedPostsDto() {
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
@@ -42,7 +42,7 @@ public class UserDto {
         return profileImage;
     }
 
-    public boolean isMyToken() {
+    public boolean getIsMyToken() {
         return isMyToken;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/exceptions/LoginFailed.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/LoginFailed.java
@@ -1,7 +1,5 @@
 package com.junstudio.kickoff.exceptions;
 
-import com.junstudio.kickoff.models.User;
-
 public class LoginFailed extends RuntimeException {
     public LoginFailed() {
         super("아이디 혹은 비밀번호가 맞지 않습니다.");

--- a/src/main/java/com/junstudio/kickoff/exceptions/PatchFailed.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/PatchFailed.java
@@ -1,0 +1,7 @@
+package com.junstudio.kickoff.exceptions;
+
+public class PatchFailed extends RuntimeException {
+    public PatchFailed() {
+        super("이미 사용중입니다. 다른 닉네임을 입력해주세요.");
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 @Entity
 @Table(name = "PERSON")
@@ -27,7 +28,8 @@ public class User {
 
     private Long gradeId;
 
-    @Column(name = "is_my_token", columnDefinition = "boolean default false")
+    @Transient
+//    @Column(name = "is_my_token", columnDefinition = "boolean default false")
     private boolean isMyToken = false;
 
     private User() {
@@ -68,6 +70,10 @@ public class User {
         return gradeId;
     }
 
+    public boolean isMyToken() {
+        return isMyToken;
+    }
+
     public UserDto toDto() {
         return new UserDto(id, identification, name, profileImage, isMyToken);
     }
@@ -82,5 +88,17 @@ public class User {
 
     public void changeTokenState() {
         isMyToken = true;
+    }
+
+    public void setTokenState() {
+        isMyToken = false;
+    }
+
+    public void update(String name, String profileImage) {
+        this.name = name;
+        if(profileImage.equals("")) {
+            return;
+        }
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/UserRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdentification(String identification);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
@@ -1,6 +1,5 @@
 package com.junstudio.kickoff.services;
 
-import com.junstudio.kickoff.exceptions.LikeNotFound;
 import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
@@ -60,5 +59,9 @@ public class DeletePostService {
         }
 
         postRepository.delete(post);
+    }
+
+    public void deletePosts(List<Long> selectedPosts) {
+        selectedPosts.forEach(postRepository::deleteById);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/services/GetUserService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetUserService.java
@@ -1,6 +1,5 @@
 package com.junstudio.kickoff.services;
 
-import com.amazonaws.services.kms.model.NotFoundException;
 import com.junstudio.kickoff.dtos.CommentDto;
 import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.ReCommentDto;
@@ -59,8 +58,12 @@ public class GetUserService {
         User user = userRepository.findById(userId)
             .orElseThrow(UserNotFound::new);
 
-        if(user.identification().equals(identification)) {
+        if (user.identification().equals(identification)) {
             user.changeTokenState();
+        }
+
+        if (!user.identification().equals(identification)) {
+            user.setTokenState();
         }
 
         List<PostDto> posts = postRepository.findAllByUserId(new UserId(userId))

--- a/src/main/java/com/junstudio/kickoff/services/PatchUserService.java
+++ b/src/main/java/com/junstudio/kickoff/services/PatchUserService.java
@@ -1,0 +1,30 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.dtos.UserDto;
+import com.junstudio.kickoff.exceptions.PatchFailed;
+import com.junstudio.kickoff.exceptions.UserNotFound;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class PatchUserService {
+    private final UserRepository userRepository;
+
+    public PatchUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void patch(Long userId, UserDto userDto) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFound::new);
+
+        if (userRepository.existsByName(userDto.getName())) {
+            throw new PatchFailed();
+        }
+
+        user.update(userDto.getName(), userDto.getProfileImage());
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/controllers/PostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.dtos.PostDetailDto;
+import com.junstudio.kickoff.dtos.SelectedPostsDto;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Like;
@@ -22,6 +23,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
@@ -132,5 +135,21 @@ class PostControllerTest {
             .andExpect(status().isNoContent());
 
         verify(deletePostService).delete(post.id());
+    }
+
+    @Test
+    void selectedPostsDelete() throws Exception {
+        SelectedPostsDto selectedPostsDto = new SelectedPostsDto(List.of(1L, 2L));
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/posts")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"postsId\": [1, 2]" +
+                    "}")
+            )
+            .andExpect(status().isNoContent());
+
+        verify(deletePostService).deletePosts(selectedPostsDto.postsId);
     }
 }

--- a/src/test/java/com/junstudio/kickoff/controllers/UserControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.services.GetUserService;
+import com.junstudio.kickoff.services.PatchUserService;
 import com.junstudio.kickoff.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -32,6 +34,9 @@ class UserControllerTest {
 
     @MockBean
     private GetUserService getUserService;
+
+    @MockBean
+    private PatchUserService patchUserService;
 
     @SpyBean
     private JwtUtil jwtUtil;
@@ -94,11 +99,23 @@ class UserControllerTest {
             );
 
         mockMvc.perform(MockMvcRequestBuilders.get("/users/1")
-                .header("Authorization", "Bearer " + token)
-                .content("userId\":\"1"))
+                .header("Authorization", "Bearer " + token))
             .andExpect(status().isOk())
             .andExpect(content().string(
                 containsString("title\":\"Son is EPL King")
             ));
+    }
+
+    @Test
+    void patch() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/users/1")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"name\":\"son\"," +
+                    "\"profileImage\":\"image\"" +
+                    "}")
+            )
+            .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/DeletePostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/DeletePostServiceTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -29,6 +32,8 @@ class DeletePostServiceTest {
     @MockBean
     private RecommentRepository recommentRepository;
 
+    private DeletePostService deletePostService;
+
     private Post post;
     private Like like;
     private Comment comment;
@@ -45,13 +50,17 @@ class DeletePostServiceTest {
         likeRepository = mock(LikeRepository.class);
         commentRepository = mock(CommentRepository.class);
         recommentRepository = mock(RecommentRepository.class);
+
+        deletePostService = new DeletePostService(
+            postRepository,
+            likeRepository,
+            commentRepository,
+            recommentRepository
+        );
     }
 
     @Test
     void delete() {
-        DeletePostService deletePostService
-            = new DeletePostService(postRepository, likeRepository, commentRepository, recommentRepository);
-
         given(postRepository.getReferenceById(post.id())).willReturn(post);
         given(likeRepository.getReferenceByPostId(post.id())).willReturn(like);
         given(commentRepository.getReferenceByPostId(post.id())).willReturn(comment);
@@ -60,5 +69,18 @@ class DeletePostServiceTest {
         deletePostService.delete(post.id());
 
         verify(postRepository).delete(post);
+    }
+
+    @Test
+    void deletePosts() {
+        List<Long> postsId = new ArrayList<>();
+
+        postsId.add(1L);
+        postsId.add(2L);
+
+        deletePostService.deletePosts(postsId);
+
+        verify(postRepository).deleteById(postsId.get(0));
+        verify(postRepository).deleteById(postsId.get(1));
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
@@ -10,10 +10,8 @@ import com.junstudio.kickoff.repositories.LikeRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
 import com.junstudio.kickoff.repositories.RecommentRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
-import com.junstudio.kickoff.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import java.util.Optional;
 

--- a/src/test/java/com/junstudio/kickoff/services/PatchUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PatchUserServiceTest.java
@@ -1,0 +1,43 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.dtos.UserDto;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class PatchUserServiceTest {
+    UserRepository userRepository;
+
+    @Test
+    void patch() {
+        userRepository = mock(UserRepository.class);
+        PatchUserService patchUserService = new PatchUserService(userRepository);
+
+        User user = spy(new User(1L, "jel1y", "encodedPassword",
+            "Jun", "profileImage", 1L, false));
+
+        given(userRepository.findById(any(Long.class))).willReturn(Optional.of(user));
+
+        UserDto userDto = new UserDto(
+            user.id(),
+            user.identification(),
+            user.name(),
+            user.profileImage(),
+            user.isMyToken()
+        );
+
+        patchUserService.patch(user.id(), userDto);
+
+        verify(user).update(user.name(), user.identification());
+    }
+}


### PR DESCRIPTION
- 사용자의 닉네임 또는 프로필 사진을 변경할 수 있다.
- 이미 사용중인 닉네임은 사용하지 못하도록 중복 닉네임 예외 처리
- 프로필 이미지 선택하지 않을 시 기존 프로필 사진 유지
- 마이 페이지에서 선택한 게시글의 아이디값을 배열로 받아 모두 삭제 처리