### PR TITLE
유저 등급을 위한 VO 생성 및 등업 신청 게시글 어드민이 관리하는 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
@@ -1,0 +1,20 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
+import com.junstudio.kickoff.admin.services.GetApplicationPostService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminApplicationPostController {
+    private final GetApplicationPostService getApplicationPostService;
+
+    public AdminApplicationPostController(GetApplicationPostService getApplicationPostService) {
+        this.getApplicationPostService = getApplicationPostService;
+    }
+
+    @GetMapping("/posts")
+    private ApplicationPostsDto applicationPosts() {
+        return getApplicationPostService.applicationPosts();
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminGradeController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminGradeController.java
@@ -1,0 +1,32 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.admin.services.PatchGradeService;
+import com.junstudio.kickoff.dtos.ApplicationFormDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin
+public class AdminGradeController {
+    private final PatchGradeService patchGradeService;
+
+    public AdminGradeController(PatchGradeService patchGradeService) {
+        this.patchGradeService = patchGradeService;
+    }
+
+    @PatchMapping("/grade")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void patchGrade(
+        @RequestBody ApplicationFormDto applicationFormDto
+    ) {
+        patchGradeService.patch(
+            applicationFormDto.getApplicationPostId(),
+            applicationFormDto.getGrade(),
+            applicationFormDto.getUserName()
+        );
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/services/GetApplicationPostService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/GetApplicationPostService.java
@@ -1,0 +1,28 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.ApplicationPostDto;
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class GetApplicationPostService {
+    private final ApplicationPostRepository applicationPostRepository;
+
+    public GetApplicationPostService(ApplicationPostRepository applicationPostRepository) {
+        this.applicationPostRepository = applicationPostRepository;
+    }
+
+    public ApplicationPostsDto applicationPosts() {
+        List<ApplicationPostDto> applicationPosts = applicationPostRepository.findAll()
+            .stream().map(ApplicationPost::toDto).collect(Collectors.toList());
+
+        return new ApplicationPostsDto(applicationPosts);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/services/PatchGradeService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/PatchGradeService.java
@@ -1,0 +1,30 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.exceptions.UserNotFound;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class PatchGradeService {
+    private final UserRepository userRepository;
+    private final ApplicationPostRepository applicationPostRepository;
+
+    public PatchGradeService(UserRepository userRepository,
+                             ApplicationPostRepository applicationPostRepository) {
+        this.userRepository = userRepository;
+        this.applicationPostRepository = applicationPostRepository;
+    }
+
+    public void patch(Long applicationPostId, String grade, String userName) {
+        User user = userRepository.findByName(userName).orElseThrow(UserNotFound::new);
+
+        user.changeGrade(grade);
+
+        applicationPostRepository.deleteById(applicationPostId);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/backdoor/BackdoorController.java
+++ b/src/main/java/com/junstudio/kickoff/backdoor/BackdoorController.java
@@ -31,20 +31,20 @@ public class BackdoorController {
         jdbcTemplate.execute("DELETE FROM person");
 
         jdbcTemplate.update("" +
-            "INSERT INTO person" +
-            "(user_id, identification, encoded_password, name, profile_image, grade_id)" +
-            " VALUES(1, ?, ?, 'son7'," +
-            " 'https://kickoffproject.s3.ap-northeast-2.amazonaws.com/kickoffproject/7fb14f2b-f348-426b-a9af-c54e410941da%E1%84%91%E1%85%B5%E1%84%8F%E1%85%A1%E1%84%8E%E1%85%B2.jpeg'," +
-            " 1)"
+                "INSERT INTO person" +
+                "(user_id, identification, encoded_password, name, profile_image, user_grade)" +
+                " VALUES(1, ?, ?, 'son7'," +
+                " 'https://kickoffproject.s3.ap-northeast-2.amazonaws.com/kickoffproject/7fb14f2b-f348-426b-a9af-c54e410941da%E1%84%91%E1%85%B5%E1%84%8F%E1%85%A1%E1%84%8E%E1%85%B2.jpeg'," +
+                " '아마추어')"
             , "jel1y", passwordEncoder.encode("Qwe1234!")
         );
 
         jdbcTemplate.update("" +
                 "INSERT INTO person" +
-                "(user_id, identification, encoded_password, name, profile_image, grade_id)" +
+                "(user_id, identification, encoded_password, name, profile_image, user_grade)" +
                 " VALUES(2, ?, ?, 'Jun'," +
                 " 'https://kickoffproject.s3.ap-northeast-2.amazonaws.com/kickoffproject/7fb14f2b-f348-426b-a9af-c54e410941da%E1%84%91%E1%85%B5%E1%84%8F%E1%85%A1%E1%84%8E%E1%85%B2.jpeg'," +
-                " 1)"
+                " '아마추어')"
             , "stw550", passwordEncoder.encode("Qwe1234!")
         );
 
@@ -95,20 +95,20 @@ public class BackdoorController {
 
         for (long i = 1; i <= 11; i += 1) {
             jdbcTemplate.update("" +
-                "INSERT INTO post" +
-                "(post_id, post_title, post_content, user_id, board_id, hit, image_url, created_at)" +
-                " VALUES(?, '카타르 월드컵 개최 일주일 전', '월드컵 기대가 됩니다.', 1, 1, 10," +
-                " 'https://kickoffproject.s3.ap-northeast-2.amazonaws.com/kickoffproject/aac172c5-45bf-47f9-aabd-6ff671204bfaLaLiga.jpg'," +
-                " '2022-11-14')"
+                    "INSERT INTO post" +
+                    "(post_id, post_title, post_content, user_id, board_id, hit, image_url, created_at)" +
+                    " VALUES(?, '카타르 월드컵 개최 일주일 전', '월드컵 기대가 됩니다.', 1, 1, 10," +
+                    " 'https://kickoffproject.s3.ap-northeast-2.amazonaws.com/kickoffproject/aac172c5-45bf-47f9-aabd-6ff671204bfaLaLiga.jpg'," +
+                    " '2022-11-14')"
                 , i
             );
         }
 
         for (long i = 1; i <= 21; i += 1) {
             jdbcTemplate.update("" +
-                "INSERT INTO comment" +
-                "(comment_id, comment_date, content, post_id, user_id, is_deleted)" +
-                " VALUES(?, '2022-11-14', '대한민국 16강 응원합니다.', 1, 1, 'false')"
+                    "INSERT INTO comment" +
+                    "(comment_id, comment_date, content, post_id, user_id, is_deleted)" +
+                    " VALUES(?, '2022-11-14', '대한민국 16강 응원합니다.', 1, 1, 'false')"
                 , i
             );
         }

--- a/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
@@ -1,0 +1,30 @@
+package com.junstudio.kickoff.controllers;
+
+import com.junstudio.kickoff.dtos.ApplicationFormDto;
+import com.junstudio.kickoff.services.CreateApplicationPostService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ApplicationPostController {
+    private final CreateApplicationPostService createApplicationPostService;
+
+    public ApplicationPostController(CreateApplicationPostService createApplicationPostService) {
+        this.createApplicationPostService = createApplicationPostService;
+    }
+
+    @PostMapping("/application")
+    @ResponseStatus(HttpStatus.CREATED)
+    private String application(
+        @RequestBody ApplicationFormDto applicationFormDto) {
+        createApplicationPostService.createApplicationPost(
+            applicationFormDto.getUserId(),
+            applicationFormDto.getGrade(),
+            applicationFormDto.getReason());
+
+        return "신청이 완료되었습니다.";
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.controllers;
 
+import com.junstudio.kickoff.dtos.BoardDto;
 import com.junstudio.kickoff.dtos.BoardsDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.services.GetBoardService;
@@ -7,8 +8,13 @@ import com.junstudio.kickoff.services.GetPostService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,5 +49,16 @@ public class BoardController {
         String keywordType
     ) {
         return getPostService.search(boardId, keyword, keywordType, pageable);
+    }
+
+    @PostMapping("/board")
+    @ResponseStatus(HttpStatus.CREATED)
+    private String createBoard(
+        @RequestBody BoardDto boardDto,
+        @RequestAttribute("identification") String identification
+    ) {
+        getPostService.createPost(boardDto.getBoardName(), identification);
+
+        return "OK";
     }
 }

--- a/src/main/java/com/junstudio/kickoff/controllers/UserController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/UserController.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("users")
 @CrossOrigin
 public class UserController {
     private final GetUserService getUserService;
@@ -48,7 +47,7 @@ public class UserController {
         this.createUserService = createUserService;
     }
 
-    @GetMapping()
+    @GetMapping("/users")
     private UsersDto users() {
         List<UserDto> users = getUserService.users()
             .stream().map(User::toDto)
@@ -57,7 +56,7 @@ public class UserController {
         return new UsersDto(users);
     }
 
-    @PostMapping
+    @PostMapping("/users")
     @ResponseStatus(HttpStatus.CREATED)
     private RegistrationResultDto register(
         @Valid @RequestBody RegistrationRequestDto registrationRequestDto
@@ -72,25 +71,26 @@ public class UserController {
         return new RegistrationResultDto(user.name());
     }
 
-    @GetMapping("me")
-    public UserDto user(
-        @RequestAttribute("identification") String identification
+    @GetMapping("/user")
+    public UserInformationDto user(
+        @RequestAttribute("identification") String identification,
+        String userName
     ) {
-        User user = getUserService.findMyInformation(identification);
-        return user.toDto();
-    }
-
-    @GetMapping("{userId}")
-    public UserInformationDto information(
-        @PathVariable Long userId,
-        @RequestAttribute("identification") String identification
-    ) {
-        UsersDto usersDto = getUserService.findUser(userId, identification);
+        UsersDto usersDto = getUserService.findUser(userName, identification);
 
         return new UserInformationDto(usersDto);
     }
 
-    @PatchMapping("{userId}")
+    @GetMapping("/users/me")
+    public UserInformationDto information(
+        @RequestAttribute("identification") String identification
+    ) {
+        UsersDto usersDto = getUserService.findMyInformation(identification);
+
+        return new UserInformationDto(usersDto);
+    }
+
+    @PatchMapping("/users/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void update(
         @RequestBody UserDto userDto,
@@ -98,7 +98,6 @@ public class UserController {
     ) {
         patchUserService.patch(userId, userDto);
     }
-
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/junstudio/kickoff/dtos/ApplicationFormDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ApplicationFormDto.java
@@ -1,0 +1,42 @@
+package com.junstudio.kickoff.dtos;
+
+public class ApplicationFormDto {
+    private final Long applicationPostId;
+
+    private Long userId;
+
+    private final String grade;
+
+    private String reason;
+
+    private final String userName;
+
+
+    public ApplicationFormDto(Long applicationPostId,
+                              String grade,
+                              String userName) {
+        this.applicationPostId = applicationPostId;
+        this.grade = grade;
+        this.userName = userName;
+    }
+
+    public Long getApplicationPostId() {
+        return applicationPostId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getGrade() {
+        return grade;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostDto.java
@@ -1,0 +1,34 @@
+package com.junstudio.kickoff.dtos;
+
+import com.junstudio.kickoff.models.Applicant;
+import com.junstudio.kickoff.models.CreationNumber;
+
+public class ApplicationPostDto {
+    private final Long id;
+    private final String reason;
+    private final Applicant applicant;
+    private final CreationNumber creationNumber;
+
+    public ApplicationPostDto(Long id, String reason, Applicant applicant, CreationNumber creationNumber) {
+        this.id = id;
+        this.reason = reason;
+        this.applicant = applicant.toDto();
+        this.creationNumber = creationNumber.toDto();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Applicant getApplicant() {
+        return applicant;
+    }
+
+    public CreationNumber getCreationNumber() {
+        return creationNumber;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostsDto.java
@@ -1,0 +1,15 @@
+package com.junstudio.kickoff.dtos;
+
+import java.util.List;
+
+public class ApplicationPostsDto {
+    private final List<ApplicationPostDto> applicationPosts;
+
+    public ApplicationPostsDto(List<ApplicationPostDto> applicationPosts) {
+        this.applicationPosts = applicationPosts;
+    }
+
+    public List<ApplicationPostDto> getApplicationPosts() {
+        return applicationPosts;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/UserDto.java
@@ -9,6 +9,8 @@ public class UserDto {
 
     private final String profileImage;
 
+    private final String grade;
+
     private final boolean isMyToken;
 
     public UserDto(
@@ -16,13 +18,14 @@ public class UserDto {
         String identification,
         String name,
         String profileImage,
+        String grade,
         boolean isMyToken
     ) {
-
         this.id = id;
         this.identification = identification;
         this.name = name;
         this.profileImage = profileImage;
+        this.grade = grade;
         this.isMyToken = isMyToken;
     }
 
@@ -40,6 +43,10 @@ public class UserDto {
 
     public String getProfileImage() {
         return profileImage;
+    }
+
+    public String getGrade() {
+        return grade;
     }
 
     public boolean getIsMyToken() {

--- a/src/main/java/com/junstudio/kickoff/exceptions/AlreadyAppliedUser.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/AlreadyAppliedUser.java
@@ -1,0 +1,7 @@
+package com.junstudio.kickoff.exceptions;
+
+public class AlreadyAppliedUser extends RuntimeException {
+    public AlreadyAppliedUser() {
+        super("이미 신청 상태입니다.");
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/Applicant.java
+++ b/src/main/java/com/junstudio/kickoff/models/Applicant.java
@@ -1,0 +1,37 @@
+package com.junstudio.kickoff.models;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Applicant {
+    private String name;
+
+    private String currentGrade;
+
+    private String applicationGrade;
+
+    public Applicant() {
+    }
+
+    public Applicant(String name, String currentGrade, String applicationGrade) {
+        this.name = name;
+        this.currentGrade = currentGrade;
+        this.applicationGrade = applicationGrade;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCurrentGrade() {
+        return currentGrade;
+    }
+
+    public String getApplicationGrade() {
+        return applicationGrade;
+    }
+
+    public Applicant toDto() {
+        return new Applicant(name, currentGrade, applicationGrade);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/ApplicationPost.java
+++ b/src/main/java/com/junstudio/kickoff/models/ApplicationPost.java
@@ -1,0 +1,75 @@
+package com.junstudio.kickoff.models;
+
+import com.junstudio.kickoff.dtos.ApplicationPostDto;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class ApplicationPost {
+    @Id
+    @GeneratedValue
+    @Column(name = "application_id")
+    private Long id;
+
+    private String reason;
+
+    @Embedded
+    private Applicant applicant;
+
+    @Embedded
+    private CreationNumber creationNumber;
+
+    public ApplicationPost() {
+    }
+
+    public ApplicationPost(Long id, String reason, Applicant applicant, CreationNumber creationNumber) {
+        this.id = id;
+        this.reason = reason;
+        this.applicant = applicant;
+        this.creationNumber = creationNumber;
+    }
+
+    public ApplicationPost(Long id, Applicant applicant, CreationNumber creationNumber) {
+        this.id = id;
+        this.applicant = applicant;
+        this.creationNumber = creationNumber;
+    }
+
+    public ApplicationPost(String reason, Applicant applicant, CreationNumber creationNumber) {
+        this.reason = reason;
+        this.applicant = applicant;
+        this.creationNumber = creationNumber;
+    }
+
+    public Long id() {
+        return id;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    public CreationNumber creationNumber() {
+        return creationNumber;
+    }
+
+    public Applicant applicant() {
+        return applicant;
+    }
+
+    public ApplicationPostDto toDto() {
+        return new ApplicationPostDto(id, reason, applicant, creationNumber);
+    }
+
+    public static ApplicationPost fake() {
+        return new ApplicationPost(
+            1L,
+            "reason",
+            new Applicant("son", "아마추어", "프로"),
+            new CreationNumber(1L, 1L));
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/Board.java
+++ b/src/main/java/com/junstudio/kickoff/models/Board.java
@@ -29,6 +29,10 @@ public class Board {
         this.parentId = parentId;
     }
 
+    public Board(BoardName boardName) {
+        this.boardName = boardName;
+    }
+
     public Long id() {
         return id;
     }

--- a/src/main/java/com/junstudio/kickoff/models/Comment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Comment.java
@@ -7,7 +7,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Transient;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 

--- a/src/main/java/com/junstudio/kickoff/models/CreationNumber.java
+++ b/src/main/java/com/junstudio/kickoff/models/CreationNumber.java
@@ -1,0 +1,30 @@
+package com.junstudio.kickoff.models;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class CreationNumber {
+    private Long postNumber;
+
+    private Long commentNumber;
+
+    public CreationNumber() {
+    }
+
+    public CreationNumber(Long postNumber, Long commentNumber) {
+        this.postNumber = postNumber;
+        this.commentNumber = commentNumber;
+    }
+
+    public Long getPostNumber() {
+        return postNumber;
+    }
+
+    public Long getCommentNumber() {
+        return commentNumber;
+    }
+
+    public CreationNumber toDto() {
+        return new CreationNumber(postNumber, commentNumber);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/Grade.java
+++ b/src/main/java/com/junstudio/kickoff/models/Grade.java
@@ -1,32 +1,42 @@
 package com.junstudio.kickoff.models;
 
 import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.Embeddable;
+import java.util.Objects;
 
-@Entity
+@Embeddable
 public class Grade {
-    @Id
-    @GeneratedValue
-    @Column(name = "grade_id")
-    private Long id;
-
+    @Column(name = "user_grade")
     private String name;
 
     public Grade() {
     }
 
-    public Grade(Long id, String name) {
-        this.id = id;
+    public Grade(String name) {
         this.name = name;
     }
 
-    public Long getId() {
-        return id;
+    public String name() {
+        return name;
     }
 
-    public String getName() {
-        return name;
+    @Override
+    public String toString() {
+        return "Grade{" +
+            "name='" + name + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Grade grade = (Grade) o;
+        return Objects.equals(name, grade.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -4,6 +4,7 @@ import com.junstudio.kickoff.dtos.UserDto;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -26,8 +27,8 @@ public class User {
 
     private String profileImage;
 
-    @Column(columnDefinition = "Long default 1L")
-    private Long gradeId;
+    @Embedded
+    private Grade grade;
 
     @Transient
     private boolean isMyToken = false;
@@ -38,18 +39,23 @@ public class User {
     public User(String name, String identification) {
         this.name = name;
         this.identification = identification;
-        this.gradeId = 1L;
+        this.grade = new Grade("아마추어");
     }
 
     public User(Long id, String identification, String encodedPassword,
-                String name, String profileImage, Long gradeId, boolean isMyToken) {
+                String name, String profileImage, Grade grade, boolean isMyToken) {
         this.id = id;
         this.identification = identification;
         this.encodedPassword = encodedPassword;
         this.name = name;
         this.profileImage = profileImage;
-        this.gradeId = gradeId;
+        this.grade = grade;
         this.isMyToken = isMyToken;
+    }
+
+    public static User fake() {
+        return new User(1L, "jel1y", "password",
+            "Jun", "profileImage", new Grade("아마추어"), false);
     }
 
     public Long id() {
@@ -72,8 +78,8 @@ public class User {
         return profileImage;
     }
 
-    public Long gradeId() {
-        return gradeId;
+    public Grade grade() {
+        return grade;
     }
 
     public boolean isMyToken() {
@@ -81,7 +87,7 @@ public class User {
     }
 
     public UserDto toDto() {
-        return new UserDto(id, identification, name, profileImage, isMyToken);
+        return new UserDto(id, identification, name, profileImage, grade.name(), isMyToken);
     }
 
     public boolean authenticate(String password, PasswordEncoder passwordEncoder) {
@@ -106,5 +112,9 @@ public class User {
             return;
         }
         this.profileImage = profileImage;
+    }
+
+    public void changeGrade(String grade) {
+        this.grade = new Grade(grade);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/ApplicationPostRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/ApplicationPostRepository.java
@@ -1,0 +1,8 @@
+package com.junstudio.kickoff.repositories;
+
+import com.junstudio.kickoff.models.ApplicationPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationPostRepository extends JpaRepository<ApplicationPost, Long> {
+    boolean existsByApplicant_Name(String name);
+}

--- a/src/main/java/com/junstudio/kickoff/repositories/GradeRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/GradeRepository.java
@@ -1,7 +1,0 @@
-package com.junstudio.kickoff.repositories;
-
-import com.junstudio.kickoff.models.Grade;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface GradeRepository extends JpaRepository<Grade, Long> {
-}

--- a/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
@@ -1,0 +1,62 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.exceptions.AlreadyAppliedUser;
+import com.junstudio.kickoff.exceptions.UserNotFound;
+import com.junstudio.kickoff.models.Applicant;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.models.CreationNumber;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.models.UserId;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class CreateApplicationPostService {
+    private final ApplicationPostRepository applicationPostRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+
+    public CreateApplicationPostService(ApplicationPostRepository applicationPostRepository,
+                                        UserRepository userRepository,
+                                        PostRepository postRepository,
+                                        CommentRepository commentRepository,
+                                        RecommentRepository recommentRepository) {
+        this.applicationPostRepository = applicationPostRepository;
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+        this.recommentRepository = recommentRepository;
+    }
+
+    public void createApplicationPost(Long userId, String grade, String reason) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFound::new);
+
+        if(applicationPostRepository.existsByApplicant_Name(user.name())) {
+            throw new AlreadyAppliedUser();
+        }
+
+        Long postNumber = (long) postRepository.findAllByUserId(new UserId(user.id())).size();
+
+        Long commentNumber = (long) commentRepository.findAllByUserId(user.id()).size();
+
+        Long recommentNumber = (long) recommentRepository.findAllByUserId(user.id()).size();
+
+        ApplicationPost applicationPost =
+            new ApplicationPost(
+                reason,
+                new Applicant(user.name(), user.grade().name(), grade),
+                new CreationNumber(postNumber, commentNumber + recommentNumber)
+            );
+
+        applicationPostRepository.save(applicationPost);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/DeletePostService.java
@@ -42,6 +42,9 @@ public class DeletePostService {
     }
 
     public void deletePosts(List<Long> selectedPosts) {
+        selectedPosts.forEach(this::deleteLikes);
+        selectedPosts.forEach(this::deleteComments);
+        selectedPosts.forEach(this::deleteRecomments);
         selectedPosts.forEach(postRepository::deleteById);
     }
 

--- a/src/main/java/com/junstudio/kickoff/services/GetPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetPostService.java
@@ -14,6 +14,7 @@ import com.junstudio.kickoff.exceptions.BoardNotFound;
 import com.junstudio.kickoff.exceptions.PostNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.models.BoardName;
 import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
@@ -195,6 +196,18 @@ public class GetPostService {
         return boardRepository.findAll()
             .stream().map(Board::toDto)
             .collect(Collectors.toList());
+    }
+
+    public void createPost(BoardName boardName, String identification) {
+        User user = userRepository.findByIdentification(identification).orElseThrow();
+
+        if (user.grade().name().equals("매니저")) {
+            throw new BoardNotFound();
+        }
+
+        Board board = new Board(boardName);
+
+        boardRepository.save(board);
     }
 }
 

--- a/src/main/java/com/junstudio/kickoff/services/LoginService.java
+++ b/src/main/java/com/junstudio/kickoff/services/LoginService.java
@@ -3,9 +3,7 @@ package com.junstudio.kickoff.services;
 import com.junstudio.kickoff.dtos.LoginResultDto;
 import com.junstudio.kickoff.exceptions.LoginFailed;
 import com.junstudio.kickoff.exceptions.UserNotFound;
-import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.User;
-import com.junstudio.kickoff.repositories.GradeRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
 import com.junstudio.kickoff.utils.JwtUtil;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,16 +15,13 @@ import java.util.HashMap;
 public class LoginService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final GradeRepository gradeRepository;
     private final JwtUtil jwtUtil;
 
     public LoginService(UserRepository userRepository,
                         PasswordEncoder passwordEncoder,
-                        GradeRepository gradeRepository,
                         JwtUtil jwtUtil) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
-        this.gradeRepository = gradeRepository;
         this.jwtUtil = jwtUtil;
     }
 
@@ -36,20 +31,18 @@ public class LoginService {
 
         String accessToken = jwtUtil.encode(identification);
 
-        Grade grade = gradeRepository.getReferenceById(user.gradeId());
-
         if (!user.authenticate(password, passwordEncoder)) {
             throw new LoginFailed();
         }
 
-        return new LoginResultDto(accessToken, user.name(), user.profileImage(), grade.getName());
+        return new LoginResultDto(accessToken, user.name(), user.profileImage(), user.grade().name());
     }
 
     public LoginResultDto kakaoLogin(HashMap<String, Object> userInfo) {
         String name = String.valueOf(userInfo.get("nickname"));
         String identification = String.valueOf(userInfo.get("email"));
 
-        if(!userRepository.existsByIdentification(identification)) {
+        if (!userRepository.existsByIdentification(identification)) {
             User user = new User(name, identification);
 
             user.changePassword(identification, passwordEncoder);

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostControllerTest.java
@@ -1,0 +1,54 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.admin.services.GetApplicationPostService;
+import com.junstudio.kickoff.dtos.ApplicationPostDto;
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
+import com.junstudio.kickoff.models.ApplicationPost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminApplicationPostController.class)
+class AdminApplicationPostControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetApplicationPostService getApplicationPostService;
+
+    ApplicationPost applicationPost;
+
+    @BeforeEach
+    void setup() {
+        applicationPost = ApplicationPost.fake();
+    }
+
+    @Test
+    void applicationPosts() throws Exception {
+        given(getApplicationPostService.applicationPosts())
+            .willReturn(new ApplicationPostsDto(
+                List.of(new ApplicationPostDto(
+                    applicationPost.id(),
+                    applicationPost.reason(),
+                    applicationPost.applicant(),
+                    applicationPost.creationNumber()
+                ))));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/posts"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                containsString("\"name\":\"son\"")
+            ));
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminGradeControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminGradeControllerTest.java
@@ -1,0 +1,37 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.admin.services.PatchGradeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminGradeController.class)
+class AdminGradeControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PatchGradeService patchGradeService;
+
+    @Test
+    void patchGrade() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/grade")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"applicationPostId\":\"1\"," +
+                    "\"grade\":\"pro\"," +
+                    "\"userName\":\"son\"" +
+                    "}"))
+            .andExpect(status().isNoContent());
+
+        verify(patchGradeService).patch(1L, "pro", "son");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/services/GetApplicationPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/GetApplicationPostServiceTest.java
@@ -1,0 +1,38 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetApplicationPostServiceTest {
+    @Test
+    void applicationPosts() {
+        ApplicationPost applicationPost = ApplicationPost.fake();
+
+        ApplicationPostRepository applicationPostRepository =
+            mock(ApplicationPostRepository.class);
+
+        GetApplicationPostService getApplicationPostService =
+            new GetApplicationPostService(applicationPostRepository);
+
+        given(applicationPostRepository.findAll())
+            .willReturn(List.of(new ApplicationPost(
+                applicationPost.id(),
+                applicationPost.reason(),
+                applicationPost.applicant(),
+                applicationPost.creationNumber()
+            )));
+
+        ApplicationPostsDto applicationPosts =
+            getApplicationPostService.applicationPosts();
+
+        assertThat(applicationPosts.getApplicationPosts().size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/services/PatchGradeServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/PatchGradeServiceTest.java
@@ -1,0 +1,33 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PatchGradeServiceTest {
+    @Test
+    void patch() {
+        User user = User.fake();
+        String applicationGrade = "프로";
+
+        UserRepository userRepository = mock(UserRepository.class);
+
+        ApplicationPostRepository applicationPostRepository = mock(ApplicationPostRepository.class);
+
+        PatchGradeService patchGradeService =
+            new PatchGradeService(userRepository, applicationPostRepository);
+
+        given(userRepository.findByName(user.name())).willReturn(Optional.of(user));
+
+        patchGradeService.patch(user.id(), applicationGrade, user.name());
+
+        verify(applicationPostRepository).deleteById(user.id());
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/controllers/ApplicationPostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/ApplicationPostControllerTest.java
@@ -1,0 +1,37 @@
+package com.junstudio.kickoff.controllers;
+
+import com.junstudio.kickoff.services.CreateApplicationPostService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplicationPostController.class)
+class ApplicationPostControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CreateApplicationPostService createApplicationPostService;
+
+    @Test
+    void application() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/application")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userId\":\"1\"," +
+                    "\"grade\":\"pro\"," +
+                    "\"reason\":\"test\"" +
+                    "}"))
+            .andExpect(status().isCreated());
+
+        verify(createApplicationPostService).createApplicationPost(1L, "pro", "test");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
@@ -8,6 +8,7 @@ import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardName;
 import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
@@ -32,7 +33,6 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -56,7 +56,7 @@ class BoardControllerTest {
 
     @BeforeEach
     void setup() {
-        user = new User(1L, "jel1y", "password", "son7", "image", 1L, false);
+        user = new User(1L, "jel1y", "password", "son7", "image", new Grade("아마추어"), false);
 
         post = Post.fake();
         comment = Comment.fake();
@@ -105,8 +105,8 @@ class BoardControllerTest {
             .willReturn(new PostsDto(
                 new CreatePostsDto(
                     List.of(post.toDto()), List.of(comment.toDto()),
-                List.of(recomment.toDto()), List.of(like.toDto()),
-                List.of(user.toDto()), List.of(board.toDto())),
+                    List.of(recomment.toDto()), List.of(like.toDto()),
+                    List.of(user.toDto()), List.of(board.toDto())),
                 new PostPageDto(1, 1L))
             );
 

--- a/src/test/java/com/junstudio/kickoff/controllers/PostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/PostControllerTest.java
@@ -4,6 +4,7 @@ import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.SelectedPostsDto;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
@@ -68,7 +69,7 @@ class PostControllerTest {
 
     @BeforeEach
     void setup() {
-        user = new User(1L, "jel1y", "password", "son7", "image", 1L, false);
+        user = new User(1L, "jel1y", "password", "son7", "image", new Grade("아마추어"), false);
 
         board = Board.fake();
         post = Post.fake();

--- a/src/test/java/com/junstudio/kickoff/controllers/SessionControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/SessionControllerTest.java
@@ -2,6 +2,7 @@ package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.dtos.LoginResultDto;
 import com.junstudio.kickoff.exceptions.LoginFailed;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.services.LoginService;
 import com.junstudio.kickoff.utils.JwtUtil;
@@ -34,7 +35,7 @@ class SessionControllerTest {
 
     @BeforeEach
     void setup() {
-        User user = new User(1L, "jel1y", "password", "jun", "url", 1L, false);
+        User user = new User(1L, "jel1y", "password", "jun", "url", new Grade("아마추어"), false);
 
         given(loginService.login("jel1y", "password"))
             .willReturn(new LoginResultDto("accessToken", user.name(), user.profileImage(), "worldClass"));

--- a/src/test/java/com/junstudio/kickoff/controllers/UserControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.junstudio.kickoff.controllers;
 import com.junstudio.kickoff.dtos.RegistrationRequestDto;
 import com.junstudio.kickoff.dtos.UsersDto;
 import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.models.User;
@@ -19,7 +20,6 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -28,6 +28,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -72,8 +73,8 @@ class UserControllerTest {
 
         identification = "je1ly";
 
-        user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, true);
+        user = new User(1L, identification, "encodedPassword",
+            "Jun", "profileImage", new Grade("아마추어"), true);
 
         post = Post.fake();
         comment = Comment.fake();
@@ -104,29 +105,38 @@ class UserControllerTest {
 
     @Test
     void findMyInformation() throws Exception {
-        given(getUserService.findMyInformation(identification)).willReturn(user);
+        given(getUserService.findMyInformation(identification)).willReturn(new UsersDto(
+            user,
+            List.of(post.toDto()),
+            List.of(comment.toDto()),
+            List.of(recomment.toDto()),
+            List.of(post.toDto())));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/users/me")
                 .header("Authorization", "Bearer " + token))
             .andExpect(status().isOk())
             .andExpect(content().string(
-                containsString("jel1y")
+                containsString("je1ly")
             ));
     }
 
     @Test
     void findUser() throws Exception {
-        given(getUserService.findUser(user.id(), identification))
-            .willReturn(new UsersDto(
-                user,
-                List.of(post.toDto()),
-                List.of(comment.toDto()),
-                List.of(recomment.toDto()),
-                List.of(post.toDto()))
-            );
+        given(getUserService.findUser(any(), any())).willReturn(new UsersDto(
+            user,
+            List.of(post.toDto()),
+            List.of(comment.toDto()),
+            List.of(recomment.toDto()),
+            List.of(post.toDto()))
+        );
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/users/1")
-                .header("Authorization", "Bearer " + token))
+        mockMvc.perform(MockMvcRequestBuilders.get("/user")
+                .header("Authorization", "Bearer " + token)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userName\":\"Jun\"" +
+                    "}"))
             .andExpect(status().isOk())
             .andExpect(content().string(
                 containsString("title\":\"Son is EPL King")

--- a/src/test/java/com/junstudio/kickoff/models/ApplicantTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/ApplicantTest.java
@@ -1,0 +1,14 @@
+package com.junstudio.kickoff.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicantTest {
+    @Test
+    void applicant() {
+        Applicant applicant = new Applicant("jun", "아마추어", "프로");
+
+        assertThat(applicant.getCurrentGrade()).isEqualTo("아마추어");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/models/ApplicationPostTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/ApplicationPostTest.java
@@ -1,0 +1,28 @@
+package com.junstudio.kickoff.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationPostTest {
+    @Test
+    void creation() {
+        ApplicationPost applicationPost =
+            new ApplicationPost(1L,
+                new Applicant("Jun", "아마추어", "프로"),
+                new CreationNumber(1L, 1L));
+
+        assertThat(applicationPost.applicant().getName()).isEqualTo("Jun");
+        assertThat(applicationPost.applicant().getCurrentGrade()).isEqualTo("아마추어");
+        assertThat(applicationPost.applicant().getApplicationGrade()).isEqualTo("프로");
+    }
+
+    @Test
+    void fake() {
+        ApplicationPost applicationPost = ApplicationPost.fake();
+
+        assertThat(applicationPost.applicant().getName()).isEqualTo("son");
+        assertThat(applicationPost.applicant().getCurrentGrade()).isEqualTo("아마추어");
+        assertThat(applicationPost.applicant().getApplicationGrade()).isEqualTo("프로");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/models/CreationNumberTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/CreationNumberTest.java
@@ -1,0 +1,15 @@
+package com.junstudio.kickoff.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreationNumberTest {
+    @Test
+    void creation() {
+        CreationNumber creationNumber = new CreationNumber(1L, 1L);
+
+        assertThat(creationNumber.getPostNumber()).isEqualTo(1L);
+        assertThat(creationNumber.getCommentNumber()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/models/GradeTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/GradeTest.java
@@ -7,8 +7,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GradeTest {
     @Test
     void grade() {
-        Grade grade = new Grade(1L, "WorldClass");
+        Grade grade = new Grade("WorldClass");
 
-        assertThat(grade.getName()).isEqualTo("WorldClass");
+        assertThat(grade.name()).isEqualTo("WorldClass");
     }
 }

--- a/src/test/java/com/junstudio/kickoff/models/LikeTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/LikeTest.java
@@ -8,7 +8,7 @@ class LikeTest {
     @Test
     void like() {
         User user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         Post post = Post.fake();
 

--- a/src/test/java/com/junstudio/kickoff/models/PostTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/PostTest.java
@@ -13,7 +13,7 @@ class PostTest {
     @BeforeEach
     void setup() {
         User user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         post = new Post(1L, new UserId(1L), 1L,
             new PostInformation("손흥민 득점왕 수상", "손흥민 아시아인 최초 EPL 득점왕"),

--- a/src/test/java/com/junstudio/kickoff/models/UserTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/UserTest.java
@@ -10,7 +10,7 @@ class UserTest {
     @Test
     void User() {
         User user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         assertThat(user.identification()).isEqualTo("jel1y");
         assertThat(user.name()).isEqualTo("Jun");
@@ -19,7 +19,7 @@ class UserTest {
     @Test
     void authenticate() {
         User user = new User(1L, "jel1y", "password",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         PasswordEncoder passwordEncoder = new Argon2PasswordEncoder();
 
@@ -27,5 +27,13 @@ class UserTest {
 
         assertThat(user.authenticate("password", passwordEncoder)).isTrue();
         assertThat(user.authenticate("xxx", passwordEncoder)).isFalse();
+    }
+
+    @Test
+    void fake() {
+        User user = User.fake();
+
+        assertThat(user.grade().name()).isEqualTo("아마추어");
+        assertThat(user.name()).isEqualTo("Jun");
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
@@ -1,0 +1,16 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.models.Applicant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CreateApplicationPostServiceTest {
+    @Test
+    void crateion() {
+        Applicant applicant = new Applicant("jun", "아마추어", "프로");
+
+        assertThat(applicant.getCurrentGrade()).isEqualTo("아마추어");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/services/CreateUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ class CreateUserServiceTest {
         CreateUserService createUserService
             = new CreateUserService(userRepository, passwordEncoder);
 
-        User user = new User(1L, "jel1y", "jun123", "jun", "profileImage", 1L, false);
+        User user = new User(1L, "jel1y", "jun123", "jun", "profileImage", new Grade("아마추어"), false);
 
         createUserService.register(
             user.name(),

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -3,6 +3,7 @@ package com.junstudio.kickoff.services;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
 import com.junstudio.kickoff.models.User;
@@ -82,7 +83,7 @@ class GetPostServiceTest {
 
         Board board = Board.fake();
         User user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         given(postRepository.findById(any())).willReturn(Optional.of(post));
         given(boardRepository.findById(any())).willReturn(Optional.of(board));

--- a/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
@@ -2,6 +2,7 @@ package com.junstudio.kickoff.services;
 
 import com.junstudio.kickoff.dtos.UsersDto;
 import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.User;
@@ -46,7 +47,7 @@ class GetUserServiceTest {
         like = Like.fake();
 
         user = new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false);
+            "Jun", "profileImage", new Grade("아마추어"), false);
 
         given(userRepository.findByIdentification(any()))
             .willReturn(Optional.of(user));
@@ -62,9 +63,9 @@ class GetUserServiceTest {
                 likeRepository,
                 recommentRepository);
 
-        User foundUser = getUserService.findMyInformation("jel1y");
+        UsersDto foundUser = getUserService.findMyInformation("jel1y");
 
-        assertThat(foundUser.name()).isEqualTo("Jun");
+        assertThat(foundUser.getUser().getName()).isEqualTo("Jun");
     }
 
     @Test
@@ -77,8 +78,8 @@ class GetUserServiceTest {
                 likeRepository,
                 recommentRepository);
 
-        given(userRepository.findById(user.id())).willReturn(Optional.of(user));
-        UsersDto users = getUserService.findUser(user.id(), user.identification());
+        given(userRepository.findByName(user.name())).willReturn(Optional.of(user));
+        UsersDto users = getUserService.findUser(user.name(), user.identification());
 
         assertThat(users.getUser().getName()).isEqualTo("Jun");
         assertThat(users.getUser().getIdentification()).isEqualTo("jel1y");

--- a/src/test/java/com/junstudio/kickoff/services/LoginServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/LoginServiceTest.java
@@ -4,7 +4,6 @@ import com.junstudio.kickoff.dtos.LoginResultDto;
 import com.junstudio.kickoff.exceptions.LoginFailed;
 import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.User;
-import com.junstudio.kickoff.repositories.GradeRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
 import com.junstudio.kickoff.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,8 +25,6 @@ class LoginServiceTest {
     @MockBean
     private UserRepository userRepository;
 
-    @MockBean
-    private GradeRepository gradeRepository;
 
     @MockBean
     private JwtUtil jwtUtil;
@@ -38,24 +35,21 @@ class LoginServiceTest {
 
     @BeforeEach
     void setup() {
-        user = new User(1L, "jel1y", "password", "jun", "url", 1L, false);
+        user = new User(1L, "jel1y", "password", "jun", "url", new Grade("아마추어"), false);
 
-        gradeRepository = mock(GradeRepository.class);
         userRepository = mock(UserRepository.class);
         passwordEncoder = new Argon2PasswordEncoder();
         jwtUtil = mock(JwtUtil.class);
 
         loginService = new LoginService(
-            userRepository, passwordEncoder, gradeRepository, jwtUtil);
+            userRepository, passwordEncoder, jwtUtil);
     }
 
     @Test
     void login() {
         user.changePassword("password", passwordEncoder);
-        Grade grade = new Grade(1L, "world class");
 
         given(userRepository.findByIdentification("jel1y")).willReturn(Optional.of(user));
-        given(gradeRepository.getReferenceById(user.gradeId())).willReturn(grade);
 
         LoginResultDto loginResultDto = loginService.login("jel1y", "password");
 

--- a/src/test/java/com/junstudio/kickoff/services/PatchUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PatchUserServiceTest.java
@@ -1,14 +1,13 @@
 package com.junstudio.kickoff.services;
 
 import com.junstudio.kickoff.dtos.UserDto;
+import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -24,7 +23,7 @@ class PatchUserServiceTest {
         PatchUserService patchUserService = new PatchUserService(userRepository);
 
         User user = spy(new User(1L, "jel1y", "encodedPassword",
-            "Jun", "profileImage", 1L, false));
+            "Jun", "profileImage", new Grade("아마추어"), false));
 
         given(userRepository.findById(any(Long.class))).willReturn(Optional.of(user));
 
@@ -33,6 +32,7 @@ class PatchUserServiceTest {
             user.identification(),
             user.name(),
             user.profileImage(),
+            user.grade().name(),
             user.isMyToken()
         );
 


### PR DESCRIPTION
- 등업 신청 게시글을 관리하기 위해 Entity 생성
- 별도의 어드민 컨트롤러 생성
- 사용자가 등업신청 게시글을 작성하면 어드민 페이지에서 해당 게시글을 확인하고 수락 또는 거절 할 수 있다.