### PR TITLE
전체 멤버 관리를 위한 모든 사용자의 정보를 찾는 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
@@ -1,20 +1,36 @@
 package com.junstudio.kickoff.admin.controllers;
 
+import com.junstudio.kickoff.admin.services.DeleteApplicationPostAdminService;
+import com.junstudio.kickoff.dtos.ApplicationFormDto;
 import com.junstudio.kickoff.dtos.ApplicationPostsDto;
 import com.junstudio.kickoff.admin.services.GetApplicationPostService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin
 public class AdminApplicationPostController {
     private final GetApplicationPostService getApplicationPostService;
+    private final DeleteApplicationPostAdminService deleteApplicationPostAdminService;
 
-    public AdminApplicationPostController(GetApplicationPostService getApplicationPostService) {
+    public AdminApplicationPostController(GetApplicationPostService getApplicationPostService,
+                                          DeleteApplicationPostAdminService deleteApplicationPostAdminService) {
         this.getApplicationPostService = getApplicationPostService;
+        this.deleteApplicationPostAdminService = deleteApplicationPostAdminService;
     }
 
     @GetMapping("/posts")
     private ApplicationPostsDto applicationPosts() {
         return getApplicationPostService.applicationPosts();
+    }
+
+    @DeleteMapping("/post")
+    private void deletePost(
+        @RequestBody ApplicationFormDto applicationFormDto
+        ) {
+        deleteApplicationPostAdminService.delete(applicationFormDto.getApplicationPostId());
     }
 }

--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminUserController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminUserController.java
@@ -1,0 +1,22 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.admin.services.GetUserAdminService;
+import com.junstudio.kickoff.dtos.UsersDto;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin
+public class AdminUserController {
+    private final GetUserAdminService getUserAdminService;
+
+    public AdminUserController(GetUserAdminService getUserAdminService) {
+        this.getUserAdminService = getUserAdminService;
+    }
+
+    @GetMapping("/admin-users")
+    private UsersDto users() {
+        return getUserAdminService.users();
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminService.java
@@ -1,0 +1,26 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.exceptions.ApplicationPostNotFound;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class DeleteApplicationPostAdminService {
+    private final ApplicationPostRepository applicationPostRepository;
+
+    public DeleteApplicationPostAdminService(ApplicationPostRepository applicationPostRepository) {
+        this.applicationPostRepository = applicationPostRepository;
+    }
+
+    public void delete(Long applicationPostId) {
+        ApplicationPost applicationPost =
+            applicationPostRepository.findById(applicationPostId)
+                .orElseThrow(ApplicationPostNotFound::new);
+
+        applicationPostRepository.delete(applicationPost);
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/services/GetUserAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/GetUserAdminService.java
@@ -1,0 +1,51 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.ManagingUsersDto;
+import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.models.UserId;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+public class GetUserAdminService {
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+
+    public GetUserAdminService(UserRepository userRepository,
+                               PostRepository postRepository,
+                               CommentRepository commentRepository,
+                               RecommentRepository recommentRepository) {
+        this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+        this.recommentRepository = recommentRepository;
+    }
+
+    public UsersDto users() {
+        List<User> foundUsers = userRepository.findAll();
+
+        List<Long> postNumbers = new ArrayList<>();
+        List<Long> commentNumbers = new ArrayList<>();
+
+        for (User user : foundUsers) {
+            postNumbers.add((long) postRepository.findAllByUserId(new UserId(user.id())).size());
+
+            commentNumbers.add(
+                (long) (commentRepository.findAllByUserId(user.id()).size() +
+                    recommentRepository.findAllByUserId(user.id()).size()));
+        }
+
+        return new UsersDto(new ManagingUsersDto(foundUsers, postNumbers, commentNumbers));
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
@@ -1,8 +1,10 @@
 package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.dtos.ApplicationFormDto;
+import com.junstudio.kickoff.exceptions.AlreadyAppliedUser;
 import com.junstudio.kickoff.services.CreateApplicationPostService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -26,5 +28,11 @@ public class ApplicationPostController {
             applicationFormDto.getReason());
 
         return "신청이 완료되었습니다.";
+    }
+
+    @ExceptionHandler(AlreadyAppliedUser.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String alreadyAppliedUser() {
+        return "이미 신청 상태입니다.";
     }
 }

--- a/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
@@ -41,6 +41,7 @@ public class BoardController {
         return getPostService.posts(boardId, pageable);
     }
 
+//    /boards/{boardId}/posts/search
     @GetMapping("/posts/{boardId}/search")
     private PostsDto searchedPosts(
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,

--- a/src/main/java/com/junstudio/kickoff/controllers/UserController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/UserController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/junstudio/kickoff/dtos/ManagingUsersDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ManagingUsersDto.java
@@ -1,0 +1,33 @@
+package com.junstudio.kickoff.dtos;
+
+import com.junstudio.kickoff.models.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ManagingUsersDto {
+    private final List<UserDto> users;
+    private final List<Long> postNumbers;
+    private final List<Long> commentNumbers;
+
+    public ManagingUsersDto(List<User> users,
+                            List<Long> postNumbers,
+                            List<Long> commentNumbers) {
+
+        this.users = users.stream().map(User::toDto).collect(Collectors.toList());
+        this.postNumbers = postNumbers;
+        this.commentNumbers = commentNumbers;
+    }
+
+    public List<UserDto> getUsers() {
+        return users;
+    }
+
+    public List<Long> getPostNumbers() {
+        return postNumbers;
+    }
+
+    public List<Long> getCommentNumbers() {
+        return commentNumbers;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/UsersDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/UsersDto.java
@@ -5,13 +5,13 @@ import com.junstudio.kickoff.models.User;
 import java.util.List;
 
 public class UsersDto {
-
     private List<UserDto> users;
     private UserDto user;
     private List<PostDto> posts;
     private List<CommentDto> comments;
     private List<ReCommentDto> reCommentDtos;
     private List<PostDto> likedPosts;
+    private ManagingUsersDto managingUsersDto;
 
     public UsersDto(List<UserDto> users) {
         this.users = users;
@@ -28,6 +28,14 @@ public class UsersDto {
         this.comments = comments;
         this.reCommentDtos = reCommentDtos;
         this.likedPosts = likedPosts;
+    }
+
+    public UsersDto(ManagingUsersDto managingUsersDto) {
+        this.managingUsersDto = managingUsersDto;
+    }
+
+    public ManagingUsersDto getMembers() {
+        return managingUsersDto;
     }
 
     public List<UserDto> getUsers() {

--- a/src/main/java/com/junstudio/kickoff/exceptions/ApplicationPostNotFound.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/ApplicationPostNotFound.java
@@ -1,0 +1,7 @@
+package com.junstudio.kickoff.exceptions;
+
+public class ApplicationPostNotFound extends RuntimeException{
+    public ApplicationPostNotFound() {
+        super("신청 게시글을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -10,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import java.util.List;
 
 @Entity
 @Table(name = "PERSON")

--- a/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
@@ -26,10 +26,10 @@ public class CreateApplicationPostService {
     private final RecommentRepository recommentRepository;
 
     public CreateApplicationPostService(ApplicationPostRepository applicationPostRepository,
-                                        UserRepository userRepository,
-                                        PostRepository postRepository,
-                                        CommentRepository commentRepository,
-                                        RecommentRepository recommentRepository) {
+                  UserRepository userRepository,
+                  PostRepository postRepository,
+                  CommentRepository commentRepository,
+                  RecommentRepository recommentRepository) {
         this.applicationPostRepository = applicationPostRepository;
         this.userRepository = userRepository;
         this.postRepository = postRepository;

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminUserControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminUserControllerTest.java
@@ -1,0 +1,44 @@
+package com.junstudio.kickoff.admin.controllers;
+
+import com.junstudio.kickoff.admin.services.GetUserAdminService;
+import com.junstudio.kickoff.dtos.ManagingUsersDto;
+import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.models.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminUserController.class)
+class AdminUserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetUserAdminService getUserAdminService;
+
+    @Test
+    void users() throws Exception {
+        User user = User.fake();
+
+        given(getUserAdminService.users())
+            .willReturn(new UsersDto(
+                new ManagingUsersDto(List.of(user), List.of(1L), List.of(1L))
+            ));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin-users"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                containsString("\"name\":\"Jun\"")
+            ));
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminServiceTest.java
@@ -1,0 +1,32 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class DeleteApplicationPostAdminServiceTest {
+    @Test
+    void delete() {
+        ApplicationPost applicationPost = ApplicationPost.fake();
+
+        ApplicationPostRepository applicationPostRepository
+            = mock(ApplicationPostRepository.class);
+
+        DeleteApplicationPostAdminService deleteApplicationPostAdminService =
+            new DeleteApplicationPostAdminService(applicationPostRepository);
+
+        given(applicationPostRepository.findById(any(Long.class)))
+            .willReturn(Optional.of(applicationPost));
+
+        deleteApplicationPostAdminService.delete(applicationPost.id());
+
+        verify(applicationPostRepository).delete(applicationPost);
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/services/GetUserAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/GetUserAdminServiceTest.java
@@ -1,0 +1,68 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.models.Comment;
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.LikeRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetUserAdminServiceTest {
+    private UserRepository userRepository;
+    private PostRepository postRepository;
+    private CommentRepository commentRepository;
+    private RecommentRepository recommentRepository;
+
+    User user;
+    Post post;
+    Comment comment;
+    Recomment recomment;
+
+    @BeforeEach
+    void setup() {
+        userRepository = mock(UserRepository.class);
+        postRepository = mock(PostRepository.class);
+        commentRepository = mock(CommentRepository.class);
+        recommentRepository = mock(RecommentRepository.class);
+
+        user = User.fake();
+        post = Post.fake();
+        comment = Comment.fake();
+        recomment = Recomment.fake();
+    }
+
+    @Test
+    void users() {
+        GetUserAdminService getUserAdminService =
+            new GetUserAdminService(
+                userRepository,
+                postRepository,
+                commentRepository,
+                recommentRepository
+            );
+
+        given(userRepository.findAll()).willReturn(List.of(user));
+        given(postRepository.findAllByUserId(any())).willReturn(List.of(post));
+        given(commentRepository.findAllByUserId(any())).willReturn(List.of(comment));
+        given(recommentRepository.findAllByUserId(any())).willReturn(List.of(recomment));
+
+        UsersDto foundUsers = getUserAdminService.users();
+
+        assertThat(foundUsers.getMembers().getUsers().size()).isEqualTo(1);
+
+        assertThat(foundUsers.getMembers().getUsers().get(0).getGrade()).isEqualTo("아마추어");
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
@@ -1,16 +1,64 @@
 package com.junstudio.kickoff.services;
 
-import com.junstudio.kickoff.models.Applicant;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.models.Recomment;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import com.junstudio.kickoff.repositories.CommentRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import com.junstudio.kickoff.repositories.RecommentRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class CreateApplicationPostServiceTest {
-    @Test
-    void crateion() {
-        Applicant applicant = new Applicant("jun", "아마추어", "프로");
+    @MockBean
+    ApplicationPostRepository applicationPostRepository;
 
-        assertThat(applicant.getCurrentGrade()).isEqualTo("아마추어");
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    PostRepository postRepository;
+
+    @MockBean
+    CommentRepository commentRepository;
+
+    @MockBean
+    RecommentRepository recommentRepository;
+
+    @Test
+    void createPost() {
+        applicationPostRepository = mock(ApplicationPostRepository.class);
+        userRepository = mock(UserRepository.class);
+        postRepository = mock(PostRepository.class);
+        commentRepository = mock(CommentRepository.class);
+        recommentRepository = mock(RecommentRepository.class);
+
+        User user = User.fake();
+
+        ApplicationPost applicationPost = ApplicationPost.fake();
+
+        CreateApplicationPostService createApplicationPostService =
+            new CreateApplicationPostService(
+                applicationPostRepository,
+                userRepository,
+                postRepository,
+                commentRepository,
+                recommentRepository
+            );
+
+        given(userRepository.findById(user.id())).willReturn(Optional.of(user));
+
+        createApplicationPostService.createApplicationPost(user.id(), "프로", applicationPost.reason());
+
+        verify(applicationPostRepository).save(any());
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetUserServiceTest.java
@@ -13,7 +13,6 @@ import com.junstudio.kickoff.repositories.RecommentRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import java.util.Optional;
 


### PR DESCRIPTION
- 사용자의 닉네임, 아이디, 등급, 작성한 개시글, 댓글 + 대댓글 개수 정보를 출력
- 작성한 게시글 개수와 댓글 개수는 각 저장소에서 사용자의 아이디로 모두 찾아서 크기를 반환