### PR TITLE
게시판 삭제 기능 구현 및 등업 신청 관리 리팩터링

### DIFF
--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminBoardController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminBoardController.java
@@ -1,22 +1,31 @@
 package com.junstudio.kickoff.admin.controllers;
 
 import com.junstudio.kickoff.admin.services.CreateBoardAdminService;
+import com.junstudio.kickoff.admin.services.DeleteBoardAdminService;
 import com.junstudio.kickoff.dtos.BoardDto;
 import com.junstudio.kickoff.exceptions.AlreadyExistingBoardName;
+import com.junstudio.kickoff.exceptions.BoardNotFound;
 import com.junstudio.kickoff.exceptions.CreateBoardFailed;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin
 public class AdminBoardController {
     private final CreateBoardAdminService createBoardAdminService;
+    private final DeleteBoardAdminService deleteBoardAdminService;
 
-    public AdminBoardController(CreateBoardAdminService createBoardAdminService) {
+    public AdminBoardController(CreateBoardAdminService createBoardAdminService,
+                                DeleteBoardAdminService deleteBoardAdminService) {
         this.createBoardAdminService = createBoardAdminService;
+        this.deleteBoardAdminService = deleteBoardAdminService;
     }
 
     @PostMapping("admin-board")
@@ -25,6 +34,14 @@ public class AdminBoardController {
         @RequestBody BoardDto boardDto
     ) {
         createBoardAdminService.create(boardDto.getParentId(), boardDto.getBoardName());
+    }
+
+    @DeleteMapping("admin-board/{boardId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    private void deleteBoard(
+        @PathVariable Long boardId
+    ) {
+        deleteBoardAdminService.delete(boardId);
     }
 
     @ExceptionHandler(CreateBoardFailed.class)
@@ -37,5 +54,11 @@ public class AdminBoardController {
     @ResponseStatus(HttpStatus.CONFLICT)
     private AlreadyExistingBoardName alreadyExistingBoardName() {
         return new AlreadyExistingBoardName();
+    }
+
+    @ExceptionHandler(BoardNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    private BoardNotFound boardNotFound() {
+        return new BoardNotFound();
     }
 }

--- a/src/main/java/com/junstudio/kickoff/admin/services/CreateBoardAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/CreateBoardAdminService.java
@@ -1,7 +1,6 @@
 package com.junstudio.kickoff.admin.services;
 
 import com.junstudio.kickoff.exceptions.AlreadyExistingBoardName;
-import com.junstudio.kickoff.exceptions.BoardNotFound;
 import com.junstudio.kickoff.exceptions.CreateBoardFailed;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardName;
@@ -9,6 +8,7 @@ import com.junstudio.kickoff.repositories.BoardRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -25,7 +25,13 @@ public class CreateBoardAdminService {
         }
 
         if(boardRepository.existsByBoardName(boardName)) {
-            throw new AlreadyExistingBoardName();
+            List<Board> foundBoards = boardRepository.findAllByBoardName(boardName);
+
+            foundBoards.forEach(foundBoard -> {
+                if(!foundBoard.isDeleted()) {
+                    throw new AlreadyExistingBoardName();
+                }
+            });
         }
 
         Board board = new Board(parentId, boardName);

--- a/src/main/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminService.java
@@ -21,6 +21,6 @@ public class DeleteApplicationPostAdminService {
             applicationPostRepository.findById(applicationPostId)
                 .orElseThrow(ApplicationPostNotFound::new);
 
-        applicationPostRepository.delete(applicationPost);
+        applicationPost.changeState("refuse");
     }
 }

--- a/src/main/java/com/junstudio/kickoff/admin/services/DeleteBoardAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/DeleteBoardAdminService.java
@@ -1,0 +1,24 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.exceptions.BoardNotFound;
+import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.repositories.BoardRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+public class DeleteBoardAdminService {
+    private final BoardRepository boardRepository;
+
+    public DeleteBoardAdminService(BoardRepository boardRepository) {
+        this.boardRepository = boardRepository;
+    }
+
+    public void delete(Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFound::new);
+
+        board.delete();
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/admin/services/PatchGradeService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/PatchGradeService.java
@@ -1,6 +1,8 @@
 package com.junstudio.kickoff.admin.services;
 
+import com.junstudio.kickoff.exceptions.ApplicationPostNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
+import com.junstudio.kickoff.models.ApplicationPost;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.ApplicationPostRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
@@ -25,6 +27,10 @@ public class PatchGradeService {
 
         user.changeGrade(grade);
 
-        applicationPostRepository.deleteById(applicationPostId);
+        ApplicationPost applicationPost = applicationPostRepository
+            .findById(applicationPostId)
+            .orElseThrow(ApplicationPostNotFound::new);
+
+        applicationPost.changeState("success");
     }
 }

--- a/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/ApplicationPostController.java
@@ -1,24 +1,40 @@
 package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.dtos.ApplicationFormDto;
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
 import com.junstudio.kickoff.exceptions.AlreadyAppliedUser;
 import com.junstudio.kickoff.services.CreateApplicationPostService;
+import com.junstudio.kickoff.services.GetApplicationPostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/application")
 public class ApplicationPostController {
     private final CreateApplicationPostService createApplicationPostService;
+    private final GetApplicationPostService getApplicationPostService;
 
-    public ApplicationPostController(CreateApplicationPostService createApplicationPostService) {
+    public ApplicationPostController(CreateApplicationPostService createApplicationPostService,
+                                     GetApplicationPostService getApplicationPostService) {
         this.createApplicationPostService = createApplicationPostService;
+        this.getApplicationPostService = getApplicationPostService;
     }
 
-    @PostMapping("/application")
+    @GetMapping
+    private ApplicationPostsDto applicationPosts(
+        @RequestAttribute("identification") String identification
+    ) {
+        return getApplicationPostService.posts(identification);
+    }
+
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     private String application(
         @RequestBody ApplicationFormDto applicationFormDto) {

--- a/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ApplicationPostDto.java
@@ -8,12 +8,19 @@ public class ApplicationPostDto {
     private final String reason;
     private final Applicant applicant;
     private final CreationNumber creationNumber;
+    private final String state;
 
-    public ApplicationPostDto(Long id, String reason, Applicant applicant, CreationNumber creationNumber) {
+    public ApplicationPostDto(Long id,
+                              String reason,
+                              Applicant applicant,
+                              CreationNumber creationNumber,
+                              String state
+    ) {
         this.id = id;
         this.reason = reason;
         this.applicant = applicant.toDto();
         this.creationNumber = creationNumber.toDto();
+        this.state = state;
     }
 
     public Long getId() {
@@ -30,5 +37,9 @@ public class ApplicationPostDto {
 
     public CreationNumber getCreationNumber() {
         return creationNumber;
+    }
+
+    public String getState() {
+        return state;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/BoardDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/BoardDto.java
@@ -9,10 +9,13 @@ public class BoardDto {
 
     private final Long parentId;
 
-    public BoardDto(Long id, BoardName boardName, Long parentId) {
+    private final boolean isDeleted;
+
+    public BoardDto(Long id, BoardName boardName, Long parentId, boolean isDeleted) {
         this.id = id;
         this.boardName = boardName.toDto();
         this.parentId = parentId;
+        this.isDeleted = isDeleted;
     }
 
     public Long getId() {
@@ -27,7 +30,11 @@ public class BoardDto {
         return parentId;
     }
 
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
     public BoardDto toDto() {
-        return new BoardDto(id, boardName, parentId);
+        return new BoardDto(id, boardName, parentId, isDeleted);
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/ApplicationPost.java
+++ b/src/main/java/com/junstudio/kickoff/models/ApplicationPost.java
@@ -23,26 +23,29 @@ public class ApplicationPost {
     @Embedded
     private CreationNumber creationNumber;
 
+    private String state;
+
     public ApplicationPost() {
     }
 
-    public ApplicationPost(Long id, String reason, Applicant applicant, CreationNumber creationNumber) {
+    public ApplicationPost(Long id,
+                           String reason,
+                           Applicant applicant,
+                           CreationNumber creationNumber,
+                           String state
+    ) {
         this.id = id;
         this.reason = reason;
         this.applicant = applicant;
         this.creationNumber = creationNumber;
-    }
-
-    public ApplicationPost(Long id, Applicant applicant, CreationNumber creationNumber) {
-        this.id = id;
-        this.applicant = applicant;
-        this.creationNumber = creationNumber;
+        this.state = state;
     }
 
     public ApplicationPost(String reason, Applicant applicant, CreationNumber creationNumber) {
         this.reason = reason;
         this.applicant = applicant;
         this.creationNumber = creationNumber;
+        this.state = "processing";
     }
 
     public Long id() {
@@ -61,8 +64,16 @@ public class ApplicationPost {
         return applicant;
     }
 
+    public String state() {
+        return state;
+    }
+
     public ApplicationPostDto toDto() {
-        return new ApplicationPostDto(id, reason, applicant, creationNumber);
+        return new ApplicationPostDto(id, reason, applicant, creationNumber, state);
+    }
+
+    public void changeState(String state) {
+        this.state = state;
     }
 
     public static ApplicationPost fake() {
@@ -70,6 +81,7 @@ public class ApplicationPost {
             1L,
             "reason",
             new Applicant("son", "아마추어", "프로"),
-            new CreationNumber(1L, 1L));
+            new CreationNumber(1L, 1L),
+            "processing");
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Board.java
+++ b/src/main/java/com/junstudio/kickoff/models/Board.java
@@ -20,6 +20,8 @@ public class Board {
 
     private Long parentId;
 
+    private boolean isDeleted;
+
     public Board() {
     }
 
@@ -27,6 +29,7 @@ public class Board {
         this.id = id;
         this.boardName = boardName;
         this.parentId = parentId;
+        this.isDeleted = false;
     }
 
     public Board(BoardName boardName) {
@@ -50,11 +53,19 @@ public class Board {
         return parentId;
     }
 
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
     public BoardDto toDto() {
-        return new BoardDto(id, boardName, parentId);
+        return new BoardDto(id, boardName, parentId, isDeleted);
     }
 
     public static Board fake() {
         return new Board(1L, new BoardName("전체 게시판"), 1L);
+    }
+
+    public void delete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/User.java
+++ b/src/main/java/com/junstudio/kickoff/models/User.java
@@ -10,7 +10,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.util.List;
 
 @Entity
 @Table(name = "PERSON")

--- a/src/main/java/com/junstudio/kickoff/repositories/ApplicationPostRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/ApplicationPostRepository.java
@@ -3,6 +3,11 @@ package com.junstudio.kickoff.repositories;
 import com.junstudio.kickoff.models.ApplicationPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ApplicationPostRepository extends JpaRepository<ApplicationPost, Long> {
     boolean existsByApplicant_Name(String name);
+
+
+    List<ApplicationPost> findAllByApplicant_Name(String name);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/BoardRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/BoardRepository.java
@@ -4,6 +4,12 @@ import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardName;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
     boolean existsByBoardName(BoardName boardName);
+
+    Board findByBoardName(BoardName boardName);
+
+    List<Board> findAllByBoardName(BoardName boardName);
 }

--- a/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CreateApplicationPostService.java
@@ -15,6 +15,7 @@ import com.junstudio.kickoff.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @Transactional
@@ -40,9 +41,14 @@ public class CreateApplicationPostService {
     public void createApplicationPost(Long userId, String grade, String reason) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFound::new);
 
-        if(applicationPostRepository.existsByApplicant_Name(user.name())) {
-            throw new AlreadyAppliedUser();
-        }
+       List<ApplicationPost> applicationPosts =
+           applicationPostRepository.findAllByApplicant_Name(user.name());
+
+       applicationPosts.forEach(applicationPost -> {
+           if(applicationPost.state().equals("processing")) {
+               throw new AlreadyAppliedUser();
+           }
+       });
 
         Long postNumber = (long) postRepository.findAllByUserId(new UserId(user.id())).size();
 

--- a/src/main/java/com/junstudio/kickoff/services/GetApplicationPostService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetApplicationPostService.java
@@ -1,0 +1,39 @@
+package com.junstudio.kickoff.services;
+
+import com.junstudio.kickoff.dtos.ApplicationPostDto;
+import com.junstudio.kickoff.dtos.ApplicationPostsDto;
+import com.junstudio.kickoff.exceptions.UserNotFound;
+import com.junstudio.kickoff.models.ApplicationPost;
+import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.repositories.ApplicationPostRepository;
+import com.junstudio.kickoff.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class GetApplicationPostService {
+    private final ApplicationPostRepository applicationPostRepository;
+    private final UserRepository userRepository;
+
+    public GetApplicationPostService(ApplicationPostRepository applicationPostRepository,
+                                     UserRepository userRepository) {
+        this.applicationPostRepository = applicationPostRepository;
+        this.userRepository = userRepository;
+    }
+
+    public ApplicationPostsDto posts(String identification) {
+        User user = userRepository.findByIdentification(identification)
+            .orElseThrow(UserNotFound::new);
+
+        List<ApplicationPostDto> applicationPosts = applicationPostRepository
+            .findAllByApplicant_Name(user.name())
+            .stream().map(ApplicationPost::toDto)
+            .collect(Collectors.toList());
+
+        return new ApplicationPostsDto(applicationPosts);
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostControllerTest.java
@@ -52,7 +52,8 @@ class AdminApplicationPostControllerTest {
                     applicationPost.id(),
                     applicationPost.reason(),
                     applicationPost.applicant(),
-                    applicationPost.creationNumber()
+                    applicationPost.creationNumber(),
+                    applicationPost.state()
                 ))));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/admin-posts"))

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminBoardControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminBoardControllerTest.java
@@ -1,6 +1,8 @@
 package com.junstudio.kickoff.admin.controllers;
 
 import com.junstudio.kickoff.admin.services.CreateBoardAdminService;
+import com.junstudio.kickoff.admin.services.DeleteBoardAdminService;
+import com.junstudio.kickoff.models.BoardName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -9,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminBoardController.class)
@@ -18,6 +22,9 @@ class AdminBoardControllerTest {
 
     @MockBean
     private CreateBoardAdminService createBoardAdminService;
+
+    @MockBean
+    private DeleteBoardAdminService deleteBoardAdminService;
 
     @Test
     void createBoard() throws Exception {
@@ -29,5 +36,15 @@ class AdminBoardControllerTest {
                     ",\"boardName\":\"testBoard\"" +
                     "}"))
             .andExpect(status().isCreated());
+
+        verify(createBoardAdminService).create(1L, new BoardName("testBoard"));
+    }
+
+    @Test
+    void deleteBoard() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin-board/1"))
+            .andExpect(status().isNoContent());
+
+        verify(deleteBoardAdminService).delete(1L);
     }
 }

--- a/src/test/java/com/junstudio/kickoff/admin/services/CreateBoardAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/CreateBoardAdminServiceTest.java
@@ -7,6 +7,8 @@ import com.junstudio.kickoff.repositories.BoardRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -43,6 +45,9 @@ class CreateBoardAdminServiceTest {
     @Test
     void createWithExistingBoardName() {
         given(boardRepository.existsByBoardName(board.boardName())).willReturn(true);
+
+        given(boardRepository.findAllByBoardName(board.boardName()))
+            .willReturn(List.of(board));
 
         assertThrows(AlreadyExistingBoardName.class, () -> {
             createBoardAdminService.create(board.parentId(), board.boardName());

--- a/src/test/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/DeleteApplicationPostAdminServiceTest.java
@@ -9,12 +9,13 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 class DeleteApplicationPostAdminServiceTest {
     @Test
     void delete() {
-        ApplicationPost applicationPost = ApplicationPost.fake();
+        ApplicationPost applicationPost = spy(ApplicationPost.fake());
 
         ApplicationPostRepository applicationPostRepository
             = mock(ApplicationPostRepository.class);
@@ -27,6 +28,6 @@ class DeleteApplicationPostAdminServiceTest {
 
         deleteApplicationPostAdminService.delete(applicationPost.id());
 
-        verify(applicationPostRepository).delete(applicationPost);
+        verify(applicationPost).changeState(any(String.class));
     }
 }

--- a/src/test/java/com/junstudio/kickoff/admin/services/DeleteBoardAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/DeleteBoardAdminServiceTest.java
@@ -1,0 +1,32 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.repositories.BoardRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class DeleteBoardAdminServiceTest {
+    BoardRepository boardRepository;
+
+    @Test
+    void delete() {
+        Board board = spy(Board.fake());
+
+        boardRepository = mock(BoardRepository.class);
+
+        given(boardRepository.findById(any(Long.class))).willReturn(Optional.of(board));
+
+        DeleteBoardAdminService deleteBoardAdminService = new DeleteBoardAdminService(boardRepository);
+
+        deleteBoardAdminService.delete(board.id());
+
+        verify(board).delete();
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/admin/services/GetApplicationPostAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/GetApplicationPostAdminServiceTest.java
@@ -27,7 +27,8 @@ class GetApplicationPostAdminServiceTest {
                 applicationPost.id(),
                 applicationPost.reason(),
                 applicationPost.applicant(),
-                applicationPost.creationNumber()
+                applicationPost.creationNumber(),
+                applicationPost.state()
             )));
 
         ApplicationPostsDto applicationPosts =

--- a/src/test/java/com/junstudio/kickoff/admin/services/PatchGradeServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/PatchGradeServiceTest.java
@@ -1,5 +1,6 @@
 package com.junstudio.kickoff.admin.services;
 
+import com.junstudio.kickoff.models.ApplicationPost;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.repositories.ApplicationPostRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
@@ -7,14 +8,18 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 class PatchGradeServiceTest {
     @Test
     void patchGrade() {
         User user = User.fake();
+        ApplicationPost applicationPost = spy(ApplicationPost.fake());
+
         String applicationGrade = "프로";
 
         UserRepository userRepository = mock(UserRepository.class);
@@ -24,10 +29,14 @@ class PatchGradeServiceTest {
         PatchGradeService patchGradeService =
             new PatchGradeService(userRepository, applicationPostRepository);
 
-        given(userRepository.findByName(user.name())).willReturn(Optional.of(user));
+        given(userRepository.findByName(user.name()))
+            .willReturn(Optional.of(user));
+
+        given(applicationPostRepository.findById(applicationPost.id()))
+            .willReturn(Optional.of(applicationPost));
 
         patchGradeService.patch(user.id(), applicationGrade, user.name());
 
-        verify(applicationPostRepository).deleteById(user.id());
+        verify(applicationPost).changeState(any(String.class));
     }
 }

--- a/src/test/java/com/junstudio/kickoff/controllers/ApplicationPostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/ApplicationPostControllerTest.java
@@ -1,15 +1,21 @@
 package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.services.CreateApplicationPostService;
+import com.junstudio.kickoff.services.GetApplicationPostService;
+import com.junstudio.kickoff.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ApplicationPostController.class)
@@ -19,6 +25,32 @@ class ApplicationPostControllerTest {
 
     @MockBean
     private CreateApplicationPostService createApplicationPostService;
+
+    @MockBean
+    private GetApplicationPostService getApplicationPostService;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    String identification;
+
+    String token;
+
+    @BeforeEach
+    void setup() {
+        identification = "jel1y";
+
+        token = jwtUtil.encode(identification);
+    }
+
+    @Test
+    void applicationPosts() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/application")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(status().isOk());
+
+        verify(getApplicationPostService).posts(identification);
+    }
 
     @Test
     void application() throws Exception {

--- a/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
@@ -68,7 +68,7 @@ class BoardControllerTest {
     @Test
     void board() throws Exception {
         given(getBoardService.boards()).willReturn(new BoardsDto(
-            List.of(new BoardDto(board.id(), new BoardName("EPL"), board.parentId()))));
+            List.of(new BoardDto(board.id(), new BoardName("EPL"), board.parentId(), false))));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/boards"))
             .andExpect(status().isOk())

--- a/src/test/java/com/junstudio/kickoff/models/ApplicationPostTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/ApplicationPostTest.java
@@ -8,7 +8,7 @@ class ApplicationPostTest {
     @Test
     void creation() {
         ApplicationPost applicationPost =
-            new ApplicationPost(1L,
+            new ApplicationPost("reason",
                 new Applicant("Jun", "아마추어", "프로"),
                 new CreationNumber(1L, 1L));
 

--- a/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateApplicationPostServiceTest.java
@@ -1,5 +1,7 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.exceptions.AlreadyAppliedUser;
+import com.junstudio.kickoff.exceptions.AlreadyExistingBoardName;
 import com.junstudio.kickoff.models.ApplicationPost;
 import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.models.User;
@@ -8,11 +10,14 @@ import com.junstudio.kickoff.repositories.CommentRepository;
 import com.junstudio.kickoff.repositories.PostRepository;
 import com.junstudio.kickoff.repositories.RecommentRepository;
 import com.junstudio.kickoff.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -34,19 +39,23 @@ class CreateApplicationPostServiceTest {
     @MockBean
     RecommentRepository recommentRepository;
 
-    @Test
-    void createPost() {
+    CreateApplicationPostService createApplicationPostService;
+
+    User user;
+    ApplicationPost applicationPost;
+
+    @BeforeEach
+    void setup() {
+        user = User.fake();
+        applicationPost = ApplicationPost.fake();
+
         applicationPostRepository = mock(ApplicationPostRepository.class);
         userRepository = mock(UserRepository.class);
         postRepository = mock(PostRepository.class);
         commentRepository = mock(CommentRepository.class);
         recommentRepository = mock(RecommentRepository.class);
 
-        User user = User.fake();
-
-        ApplicationPost applicationPost = ApplicationPost.fake();
-
-        CreateApplicationPostService createApplicationPostService =
+         createApplicationPostService =
             new CreateApplicationPostService(
                 applicationPostRepository,
                 userRepository,
@@ -54,11 +63,26 @@ class CreateApplicationPostServiceTest {
                 commentRepository,
                 recommentRepository
             );
+    }
 
+    @Test
+    void createPost() {
         given(userRepository.findById(user.id())).willReturn(Optional.of(user));
 
         createApplicationPostService.createApplicationPost(user.id(), "프로", applicationPost.reason());
 
         verify(applicationPostRepository).save(any());
+    }
+
+    @Test
+    void alreadyApplicationState() {
+        given(userRepository.findById(user.id())).willReturn(Optional.of(user));
+
+        given(applicationPostRepository.findAllByApplicant_Name(user.name()))
+            .willReturn(List.of(applicationPost));
+
+        assertThrows(AlreadyAppliedUser.class, () -> {
+            createApplicationPostService.createApplicationPost(user.id(), "프로", applicationPost.reason());
+        });
     }
 }


### PR DESCRIPTION
- 게시판 삭제 기능을 위한 게시판 엔티티에 deleted 상태를 판별할 수 있는 필드 생성
- 게시판을 삭제해도 진짜 삭제가 아닌 상태를 변경해서 안보이도록 구현 (soft delete)
- 기존에 등업 신청 거절 시 해당 게시글 지우던 방식을 신청 상태를 거절 상태로 변경해 신청 게시글 리스트에서 안보이도록 구현