### PR TITLE
게시판별 게시글 개수 구하는 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminBoardController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminBoardController.java
@@ -2,7 +2,9 @@ package com.junstudio.kickoff.admin.controllers;
 
 import com.junstudio.kickoff.admin.services.CreateBoardAdminService;
 import com.junstudio.kickoff.admin.services.DeleteBoardAdminService;
+import com.junstudio.kickoff.admin.services.GetBoardAdminService;
 import com.junstudio.kickoff.dtos.BoardDto;
+import com.junstudio.kickoff.dtos.BoardRateDto;
 import com.junstudio.kickoff.exceptions.AlreadyExistingBoardName;
 import com.junstudio.kickoff.exceptions.BoardNotFound;
 import com.junstudio.kickoff.exceptions.CreateBoardFailed;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,11 +24,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminBoardController {
     private final CreateBoardAdminService createBoardAdminService;
     private final DeleteBoardAdminService deleteBoardAdminService;
+    private final GetBoardAdminService getBoardAdminService;
 
     public AdminBoardController(CreateBoardAdminService createBoardAdminService,
-                                DeleteBoardAdminService deleteBoardAdminService) {
+                                DeleteBoardAdminService deleteBoardAdminService,
+                                GetBoardAdminService getBoardAdminService) {
         this.createBoardAdminService = createBoardAdminService;
         this.deleteBoardAdminService = deleteBoardAdminService;
+        this.getBoardAdminService = getBoardAdminService;
+    }
+
+    @GetMapping("admin-boards-rate")
+    private BoardRateDto rateBoard() {
+        return getBoardAdminService.rate();
     }
 
     @PostMapping("admin-board")

--- a/src/main/java/com/junstudio/kickoff/admin/services/GetBoardAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/GetBoardAdminService.java
@@ -1,0 +1,78 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.BoardRateDto;
+import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.repositories.BoardRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class GetBoardAdminService {
+    private final BoardRepository boardRepository;
+    private final PostRepository postRepository;
+
+    public GetBoardAdminService(BoardRepository boardRepository,
+                                PostRepository postRepository) {
+        this.boardRepository = boardRepository;
+        this.postRepository = postRepository;
+    }
+
+    public BoardRateDto rate() {
+        AtomicInteger eplBoardPostsNumber = new AtomicInteger();
+        AtomicInteger laligaBoardPostsNumber = new AtomicInteger();
+        AtomicInteger serieaBoardPostsNumber = new AtomicInteger();
+        AtomicInteger bundesligaBoardPostsNumber = new AtomicInteger();
+
+        addLeagueBoardPostsNumber(eplBoardPostsNumber, 2L);
+        addLeagueBoardPostsNumber(laligaBoardPostsNumber, 3L);
+        addLeagueBoardPostsNumber(serieaBoardPostsNumber, 4L);
+        addLeagueBoardPostsNumber(bundesligaBoardPostsNumber, 5L);
+
+        List<Board> eplTeamBoards = addTeamBoardPostsNumber(eplBoardPostsNumber, 2L);
+        List<Board> laligaTeamBoards = addTeamBoardPostsNumber(laligaBoardPostsNumber, 3L);
+        List<Board> serieaTeamBoards = addTeamBoardPostsNumber(serieaBoardPostsNumber, 4L);
+        List<Board> bundesligaTeamBoards = addTeamBoardPostsNumber(bundesligaBoardPostsNumber, 5L);
+
+        addPlayerBoardPostsNumber(eplBoardPostsNumber, eplTeamBoards);
+        addPlayerBoardPostsNumber(laligaBoardPostsNumber, laligaTeamBoards);
+        addPlayerBoardPostsNumber(serieaBoardPostsNumber, serieaTeamBoards);
+        addPlayerBoardPostsNumber(bundesligaBoardPostsNumber, bundesligaTeamBoards);
+
+        return new BoardRateDto(eplBoardPostsNumber, laligaBoardPostsNumber, serieaBoardPostsNumber, bundesligaBoardPostsNumber);
+    }
+
+    private void addLeagueBoardPostsNumber(AtomicInteger leagueBoardPostsNumber, Long boardId) {
+        List<Post> eplBoardPosts =  postRepository.findAllByBoardId(boardId);
+        leagueBoardPostsNumber.addAndGet(eplBoardPosts.size());
+    }
+
+    private List<Board> addTeamBoardPostsNumber(AtomicInteger teamBoardPostsNumber, Long boardId) {
+        List<Board> teamBoards = boardRepository.findAllByParentId(boardId);
+
+        teamBoardPostsNumber.addAndGet(teamBoards.stream()
+            .filter(eplTeamBoard -> !eplTeamBoard.isDeleted())
+            .collect(Collectors.toList())
+            .stream()
+            .mapToInt(eplTeamBoard -> postRepository.findAllByBoardId(eplTeamBoard.id())
+                .size()).sum());
+        return teamBoards;
+    }
+
+    private void addPlayerBoardPostsNumber(AtomicInteger playerBoardPostsNumber, List<Board> teamBoards) {
+        teamBoards.forEach(teamBoard -> {
+            boardRepository.findAllByParentId(teamBoard.id())
+                .stream()
+                .filter(eplPlayerBoard -> !eplPlayerBoard.isDeleted())
+                .forEach(eplPlayerBoard -> {
+                    playerBoardPostsNumber.addAndGet(postRepository.findAllByBoardId(eplPlayerBoard.id()).size());
+                });
+        });
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/BoardRateDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/BoardRateDto.java
@@ -1,0 +1,37 @@
+package com.junstudio.kickoff.dtos;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BoardRateDto {
+    private final AtomicInteger eplBoardPostsNumber;
+    private final AtomicInteger laligaBoardPostsNumber;
+    private final AtomicInteger serieaBoardPostsNumber;
+    private final AtomicInteger bundesligaBoardPostsNumber;
+
+    public BoardRateDto(AtomicInteger eplBoardPostsNumber,
+                        AtomicInteger laligaBoardPostsNumber,
+                        AtomicInteger serieaBoardPostsNumber,
+                        AtomicInteger bundesligaBoardPostsNumber) {
+
+        this.eplBoardPostsNumber = eplBoardPostsNumber;
+        this.laligaBoardPostsNumber = laligaBoardPostsNumber;
+        this.serieaBoardPostsNumber = serieaBoardPostsNumber;
+        this.bundesligaBoardPostsNumber = bundesligaBoardPostsNumber;
+    }
+
+    public AtomicInteger getEplBoardValue() {
+        return eplBoardPostsNumber;
+    }
+
+    public AtomicInteger getLaligaBoardValue() {
+        return laligaBoardPostsNumber;
+    }
+
+    public AtomicInteger getSerieaBoardValue() {
+        return serieaBoardPostsNumber;
+    }
+
+    public AtomicInteger getBundesligaBoardValue() {
+        return bundesligaBoardPostsNumber;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/repositories/BoardRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/BoardRepository.java
@@ -12,4 +12,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Board findByBoardName(BoardName boardName);
 
     List<Board> findAllByBoardName(BoardName boardName);
+
+    List<Board> findAllByParentId(Long parentId);
+
+    Board findByParentId(Long parentId);
 }

--- a/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
@@ -14,6 +14,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByBoardId(Long boardId, Pageable pageable);
 
+    List<Post> findAllByBoardId(Long boardId);
+
     List<Post> findAllByUserId(UserId userId);
 
     Page<Post> findByPostInformation_TitleContaining(String keyword, Pageable pageable);
@@ -31,4 +33,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findTop3ByOrderByHitDesc();
 
     List<Post> findByCreatedAtBetween(LocalDateTime createdAt, LocalDateTime endDatetime);
+
 }

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminBoardControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminBoardControllerTest.java
@@ -2,6 +2,8 @@ package com.junstudio.kickoff.admin.controllers;
 
 import com.junstudio.kickoff.admin.services.CreateBoardAdminService;
 import com.junstudio.kickoff.admin.services.DeleteBoardAdminService;
+import com.junstudio.kickoff.admin.services.GetBoardAdminService;
+import com.junstudio.kickoff.dtos.BoardRateDto;
 import com.junstudio.kickoff.models.BoardName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,8 +13,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminBoardController.class)
@@ -21,10 +28,38 @@ class AdminBoardControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
+    private GetBoardAdminService getBoardAdminService;
+
+    @MockBean
     private CreateBoardAdminService createBoardAdminService;
 
     @MockBean
     private DeleteBoardAdminService deleteBoardAdminService;
+
+    @Test
+    void rateBoard() throws Exception {
+        BoardRateDto boardRateDto = new BoardRateDto(
+            new AtomicInteger(1),
+            new AtomicInteger(1),
+            new AtomicInteger(1),
+            new AtomicInteger(1)
+        );
+
+        given(getBoardAdminService.rate()).willReturn(boardRateDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin-boards-rate"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                containsString("{" +
+                    "\"eplBoardValue\":1," +
+                    "\"laligaBoardValue\":1," +
+                    "\"serieaBoardValue\":1," +
+                    "\"bundesligaBoardValue\":1" +
+                    "}")
+            ));
+
+        verify(getBoardAdminService).rate();
+    }
 
     @Test
     void createBoard() throws Exception {

--- a/src/test/java/com/junstudio/kickoff/admin/services/GetBoardAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/GetBoardAdminServiceTest.java
@@ -1,0 +1,39 @@
+package com.junstudio.kickoff.admin.services;
+
+import com.junstudio.kickoff.dtos.BoardRateDto;
+import com.junstudio.kickoff.models.Board;
+import com.junstudio.kickoff.models.Post;
+import com.junstudio.kickoff.repositories.BoardRepository;
+import com.junstudio.kickoff.repositories.PostRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetBoardAdminServiceTest {
+    @Test
+    void rate() {
+        Post post = Post.fake();
+        Board board = Board.fake();
+
+        BoardRepository boardRepository = mock(BoardRepository.class);
+        PostRepository postRepository = mock(PostRepository.class);
+
+        GetBoardAdminService getBoardAdminService =
+            new GetBoardAdminService(boardRepository, postRepository);
+
+        given(postRepository.findAllByBoardId(any(Long.class)))
+            .willReturn(List.of(post));
+
+        given(boardRepository.findAllByParentId(any(Long.class)))
+            .willReturn(List.of(board));
+
+        BoardRateDto boardRateDto = getBoardAdminService.rate();
+
+        assertThat(boardRateDto.getEplBoardValue().get()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
- 4대 리그 게시판의 게시글과 하위 게시판(선수 게시판, 팀 게시판)의 게시글 개수를 합하여 프론트로 전달