### PR TITLE
인기 게시글(조회수 높은) 조회 기능 구현

### DIFF
--- a/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
@@ -2,6 +2,7 @@ package com.junstudio.kickoff.controllers;
 
 import com.junstudio.kickoff.dtos.BoardDto;
 import com.junstudio.kickoff.dtos.BoardsDto;
+import com.junstudio.kickoff.dtos.HotPostsDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.services.GetBoardService;
 import com.junstudio.kickoff.services.GetPostService;
@@ -39,6 +40,11 @@ public class BoardController {
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return getPostService.posts(boardId, pageable);
+    }
+
+    @GetMapping("/boards/posts/hot")
+    private HotPostsDto hotPosts() {
+        return getPostService.hotPosts();
     }
 
     @GetMapping("/boards/{boardId}/posts/search")

--- a/src/main/java/com/junstudio/kickoff/dtos/HotPostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/HotPostsDto.java
@@ -1,0 +1,38 @@
+package com.junstudio.kickoff.dtos;
+
+import java.util.List;
+
+public class HotPostsDto {
+    private final List<PostDto> posts;
+    private final List<Integer> commentNumbers;
+    private final List<BoardDto> hotBoards;
+    private final List<UserDto> hotUsers;
+
+
+    public HotPostsDto(List<PostDto> posts,
+                       List<Integer> commentNumbers,
+                       List<BoardDto> hotBoards,
+                       List<UserDto> hotUsers) {
+        this.posts = posts;
+        this.commentNumbers = commentNumbers;
+        this.hotBoards = hotBoards;
+        this.hotUsers = hotUsers;
+    }
+
+
+    public List<PostDto> getPosts() {
+        return posts;
+    }
+
+    public List<Integer> getCommentNumber() {
+        return commentNumbers;
+    }
+
+    public List<BoardDto> getBoards() {
+        return hotBoards;
+    }
+
+    public List<UserDto> getUsers() {
+        return hotUsers;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/PostsDto.java
@@ -1,11 +1,8 @@
 package com.junstudio.kickoff.dtos;
 
-import java.util.List;
-
 public class PostsDto {
-    private PostPageDto page;
-    private CreatePostsDto posts;
-    private List<PostDto> searchedPosts;
+    private final PostPageDto page;
+    private final CreatePostsDto posts;
 
     public PostsDto(CreatePostsDto createPostsDto, PostPageDto page) {
         this.posts = createPostsDto;

--- a/src/main/java/com/junstudio/kickoff/models/Post.java
+++ b/src/main/java/com/junstudio/kickoff/models/Post.java
@@ -72,7 +72,7 @@ public class Post {
         return userId;
     }
 
-    public BoardId getBoardId() {
+    public BoardId boardId() {
         return boardId;
     }
 
@@ -101,26 +101,9 @@ public class Post {
         this.hit = new Hit(hit + 1L);
     }
 
-    public PostWrittenDto postWrittenDto() {
-        return new PostWrittenDto(id);
-    }
-
     public PostDetailDto toDetailDto(Board board, User user) {
         return new PostDetailDto(id, postInformation, hit.number(), board, user,
             createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), image.url());
-    }
-
-    public static Post fake() {
-        return new Post(1L, new UserId(1L), new BoardId(1L),
-            new PostInformation("Son is EPL King",
-                "Son is the first Asian to score EPL"),
-            new Hit(3L), new Image("imageUrl"), LocalDateTime.now());
-    }
-
-    public void patch(String title, String content, Long boardId, String imageUrl) {
-        this.postInformation = new PostInformation(title, content);
-        this.boardId = new BoardId(boardId);
-        this.image = new Image(imageUrl);
     }
 
     public StatisticsPostDto toStatisticsDto() {
@@ -131,5 +114,27 @@ public class Post {
             hit.number(),
             createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
         );
+    }
+
+    public PostWrittenDto postWrittenDto() {
+        return new PostWrittenDto(id);
+    }
+
+    public void patch(String title, String content, Long boardId, String imageUrl) {
+        this.postInformation = new PostInformation(title, content);
+        this.boardId = new BoardId(boardId);
+        this.image = new Image(imageUrl);
+    }
+
+    public static Post fake() {
+        return new Post(1L,
+            new UserId(1L),
+            new BoardId(1L),
+            new PostInformation(
+                "Son is EPL King",
+                "Son is the first Asian to score EPL"),
+            new Hit(3L),
+            new Image("imageUrl"),
+            LocalDateTime.now());
     }
 }

--- a/src/main/java/com/junstudio/kickoff/models/Recomment.java
+++ b/src/main/java/com/junstudio/kickoff/models/Recomment.java
@@ -60,15 +60,15 @@ public class Recomment {
         return commentId;
     }
 
-    public Content getContent() {
+    public Content content() {
         return content;
     }
 
-    public UserId getUserId() {
+    public UserId userId() {
         return userId;
     }
 
-    public PostId getPostId() {
+    public PostId postId() {
         return postId;
     }
 

--- a/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/LikeRepository.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
-    Optional<Like> findByPostId_Value(Long postId);
-
     List<Like> findAllByPostId_Value(Long postId);
 
     void deleteAllById(Long postId);

--- a/src/main/java/com/junstudio/kickoff/services/CreateLikeService.java
+++ b/src/main/java/com/junstudio/kickoff/services/CreateLikeService.java
@@ -20,9 +20,9 @@ public class CreateLikeService {
         if (likeRepository.existsByPostId_Value(postId)) {
             List<Like> foundLikes = likeRepository.findAllByUserId_Value(userId);
 
-            for (int i = 0; i < foundLikes.size(); i += 1) {
-                if (foundLikes.get(i).userId().value().equals(userId)) {
-                    likeRepository.deleteById(foundLikes.get(i).id());
+            for (Like foundLike : foundLikes) {
+                if (foundLike.userId().value().equals(userId)) {
+                    likeRepository.deleteById(foundLike.id());
                     return;
                 }
             }

--- a/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/BoardControllerTest.java
@@ -3,8 +3,11 @@ package com.junstudio.kickoff.controllers;
 import com.junstudio.kickoff.dtos.BoardDto;
 import com.junstudio.kickoff.dtos.BoardsDto;
 import com.junstudio.kickoff.dtos.CreatePostsDto;
+import com.junstudio.kickoff.dtos.HotPostsDto;
+import com.junstudio.kickoff.dtos.PostDto;
 import com.junstudio.kickoff.dtos.PostPageDto;
 import com.junstudio.kickoff.dtos.PostsDto;
+import com.junstudio.kickoff.dtos.UserDto;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardId;
 import com.junstudio.kickoff.models.Comment;
@@ -30,11 +33,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -99,6 +104,26 @@ class BoardControllerTest {
             .andExpect(content().string(
                 containsString("\"title\":\"Son is EPL King\"")
             ));
+    }
+
+    @Test
+    void hotPosts() throws Exception {
+        List<PostDto> posts = List.of(post.toDto());
+        List<Integer> commentNumber = new ArrayList<>();
+        List<BoardDto> boards = List.of(board.toDto());
+        List<UserDto> users = List.of(user.toDto());
+
+        HotPostsDto hotPosts = new HotPostsDto(posts, commentNumber, boards, users);
+
+        given(getPostService.hotPosts()).willReturn(hotPosts);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/boards/posts/hot"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(
+                containsString("\"title\":\"Son is EPL King\"")
+            ));
+
+        verify(getPostService).hotPosts();
     }
 
     @Test

--- a/src/test/java/com/junstudio/kickoff/models/RecommentTest.java
+++ b/src/test/java/com/junstudio/kickoff/models/RecommentTest.java
@@ -11,6 +11,6 @@ class RecommentTest {
     void recomment() {
         Recomment recomment = new Recomment(1L, 1L, new Content("대댓글"), new UserId(1L), new PostId(1L), LocalDateTime.now());
 
-        assertThat(recomment.getContent().value()).isEqualTo("대댓글");
+        assertThat(recomment.content().value()).isEqualTo("대댓글");
     }
 }

--- a/src/test/java/com/junstudio/kickoff/services/CreateLikeServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateLikeServiceTest.java
@@ -2,18 +2,13 @@ package com.junstudio.kickoff.services;
 
 import com.junstudio.kickoff.models.Like;
 import com.junstudio.kickoff.models.Post;
-import com.junstudio.kickoff.models.PostId;
 import com.junstudio.kickoff.models.User;
-import com.junstudio.kickoff.models.UserId;
 import com.junstudio.kickoff.repositories.LikeRepository;
-import com.junstudio.kickoff.repositories.PostRepository;
-import com.junstudio.kickoff.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/junstudio/kickoff/services/CreateRecommentServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/CreateRecommentServiceTest.java
@@ -29,10 +29,10 @@ class CreateRecommentServiceTest {
         Recomment recomment = Recomment.fake();
 
         createRecommentService.createRecomment(
-            recomment.getContent().value(),
+            recomment.content().value(),
             recomment.commentId(),
-            recomment.getUserId().value(),
-            recomment.getPostId().value());
+            recomment.userId().value(),
+            recomment.postId().value());
 
         verify(recommentRepository).save(any(Recomment.class));
     }

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -1,14 +1,17 @@
 package com.junstudio.kickoff.services;
 
+import com.junstudio.kickoff.dtos.HotPostsDto;
 import com.junstudio.kickoff.dtos.PostDetailDto;
 import com.junstudio.kickoff.dtos.PostsDto;
 import com.junstudio.kickoff.models.Board;
 import com.junstudio.kickoff.models.BoardId;
+import com.junstudio.kickoff.models.Comment;
 import com.junstudio.kickoff.models.Grade;
 import com.junstudio.kickoff.models.Hit;
 import com.junstudio.kickoff.models.Image;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.PostInformation;
+import com.junstudio.kickoff.models.Recomment;
 import com.junstudio.kickoff.models.User;
 import com.junstudio.kickoff.models.UserId;
 import com.junstudio.kickoff.repositories.BoardRepository;
@@ -73,7 +76,7 @@ class GetPostServiceTest {
 
         given(postRepository.findAll(Pageable.ofSize(1))).willReturn(page);
 
-        PostsDto postsDto = getPostService.posts(post.getBoardId().value(), Pageable.ofSize(1));
+        PostsDto postsDto = getPostService.posts(post.boardId().value(), Pageable.ofSize(1));
 
         assertThat(postsDto).isNotNull();
     }
@@ -96,6 +99,29 @@ class GetPostServiceTest {
         assertThat(foundPost.getPostInformation().getTitle()).isEqualTo("EPL start");
 
         verify(postRepository).findById(any());
+    }
+
+    @Test
+    void hotPosts() {
+        Post post = Post.fake();
+        Comment comment = Comment.fake();
+        Recomment recomment = Recomment.fake();
+        Board board = Board.fake();
+        User user = User.fake();
+
+        given(postRepository.findTop3ByOrderByHit_NumberDesc()).willReturn(List.of(post));
+
+        given(commentRepository.findAllByPostId_Value(any())).willReturn(List.of(comment));
+        given(recommentRepository.findAllByPostId_Value(any())).willReturn(List.of(recomment));
+        given(boardRepository.findById(post.boardId().value())).willReturn(Optional.of(board));
+        given(userRepository.findById(post.userId().value())).willReturn(Optional.of(user));
+
+        HotPostsDto hotPosts = getPostService.hotPosts();
+
+        assertThat(hotPosts.getPosts().get(0).getPostInformation().getTitle()).isEqualTo("Son is EPL King");
+        assertThat(hotPosts.getBoards().get(0).getBoardName()).isEqualTo("전체 게시판");
+        assertThat(hotPosts.getUsers().get(0).getName()).isEqualTo("Jun");
+        assertThat(hotPosts.getCommentNumber().get(0)).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/junstudio/kickoff/services/PatchPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/PatchPostServiceTest.java
@@ -28,7 +28,7 @@ class PatchPostServiceTest {
 
         PostWriteDto postWriteDto = new PostWriteDto(post.id(),
             post.postInformation().getTitle(), post.postInformation().getContent(),
-            post.image().url(), post.userId().value(), post.getBoardId().value());
+            post.image().url(), post.userId().value(), post.boardId().value());
 
         patchPostService.patch(postWriteDto, post.id());
 


### PR DESCRIPTION
- 게시글중 조회수가 높은 순서대로 3개를 찾아 해당 게시글에 맞는 사용자의 정보, 댓글 개수, 게시판 이름을 찾아 프론트로 전달