### PR TITLE
Bucket4j 라이브러리 사용해서 rapid api 요청 횟수 관리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## Rapid API Key
+GameScheduleController.java

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.10'
 	implementation 'com.auth0:java-jwt:4.2.1'
 
+	implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminApplicationPostController.java
@@ -1,7 +1,6 @@
 package com.junstudio.kickoff.admin.controllers;
 
 import com.junstudio.kickoff.admin.services.DeleteApplicationPostAdminService;
-import com.junstudio.kickoff.dtos.ApplicationFormDto;
 import com.junstudio.kickoff.dtos.ApplicationPostsDto;
 import com.junstudio.kickoff.admin.services.GetApplicationPostAdminService;
 import org.springframework.http.HttpStatus;
@@ -9,7 +8,6 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminPostController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminPostController.java
@@ -4,7 +4,12 @@ import com.junstudio.kickoff.admin.services.GetPostAdminService;
 import com.junstudio.kickoff.dtos.PostsByDateDto;
 import com.junstudio.kickoff.dtos.StatisticsPostsDto;
 import com.junstudio.kickoff.dtos.TodayCreatePostsDto;
+import com.junstudio.kickoff.exceptions.AdminNotFound;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,12 +31,20 @@ public class AdminPostController {
     }
 
     @GetMapping("/admin-week-posts")
-    private PostsByDateDto weekPosts() {
-        return getPostAdminService.weekPosts();
+    private PostsByDateDto weekPosts(
+        @RequestAttribute("identification") String identification
+    ) {
+        return getPostAdminService.weekPosts(identification);
     }
 
     @GetMapping("/admin-total-posts")
     private int posts() {
         return getPostAdminService.posts();
+    }
+
+    @ExceptionHandler(AdminNotFound.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    private AdminNotFound adminNotFound() {
+        return new AdminNotFound();
     }
 }

--- a/src/main/java/com/junstudio/kickoff/admin/controllers/AdminUserController.java
+++ b/src/main/java/com/junstudio/kickoff/admin/controllers/AdminUserController.java
@@ -8,6 +8,7 @@ import com.junstudio.kickoff.dtos.SearchedUserDto;
 import com.junstudio.kickoff.dtos.SelectedUsersDto;
 import com.junstudio.kickoff.dtos.TodaySignupUsersDto;
 import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.exceptions.AdminNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -77,5 +78,11 @@ public class AdminUserController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     private String userNotFound() {
         return "유저를 찾을 수 없습니다.";
+    }
+
+    @ExceptionHandler(AdminNotFound.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    private AdminNotFound adminNotFound() {
+        return new AdminNotFound();
     }
 }

--- a/src/main/java/com/junstudio/kickoff/admin/services/GetPostAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/GetPostAdminService.java
@@ -4,6 +4,7 @@ import com.junstudio.kickoff.dtos.PostsByDateDto;
 import com.junstudio.kickoff.dtos.StatisticsPostDto;
 import com.junstudio.kickoff.dtos.StatisticsPostsDto;
 import com.junstudio.kickoff.dtos.TodayCreatePostsDto;
+import com.junstudio.kickoff.exceptions.AdminNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.User;
@@ -53,7 +54,11 @@ public class GetPostAdminService {
         return new TodayCreatePostsDto(posts);
     }
 
-    public PostsByDateDto weekPosts() {
+    public PostsByDateDto weekPosts(String identification) {
+        if(!userRepository.findByIdentification(identification).orElseThrow(UserNotFound::new).identification().equals("jel1y")) {
+            throw new AdminNotFound();
+        }
+
         int todayPostsNumber = postsNumber(0);
         int aDayAgoPostsNumber = postsNumber(1);
         int twoDaysAgoPostsNumber = postsNumber(2);

--- a/src/main/java/com/junstudio/kickoff/admin/services/GetUserAdminService.java
+++ b/src/main/java/com/junstudio/kickoff/admin/services/GetUserAdminService.java
@@ -5,6 +5,7 @@ import com.junstudio.kickoff.dtos.ManagingUsersDto;
 import com.junstudio.kickoff.dtos.SearchedUserDto;
 import com.junstudio.kickoff.dtos.TodaySignupUsersDto;
 import com.junstudio.kickoff.dtos.UsersDto;
+import com.junstudio.kickoff.exceptions.AdminNotFound;
 import com.junstudio.kickoff.exceptions.UserNotFound;
 import com.junstudio.kickoff.models.Admin;
 import com.junstudio.kickoff.models.Comment;
@@ -76,8 +77,13 @@ public class GetUserAdminService {
     }
 
     public AdminDto admin(String identification) {
+//        adminRepository.existsByIdentification(identification);
         Admin admin = adminRepository.findByIdentification(identification)
             .orElseThrow(UserNotFound::new);
+
+        if(!admin.identification().equals("jel1y")) {
+            throw new AdminNotFound();
+        }
 
         return new AdminDto(admin.identification(), admin.name(), admin.profileImage());
     }

--- a/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/BoardController.java
@@ -56,15 +56,4 @@ public class BoardController {
     ) {
         return getPostService.search(boardId, keyword, keywordType, pageable);
     }
-
-    @PostMapping("/board")
-    @ResponseStatus(HttpStatus.CREATED)
-    private String createBoard(
-        @RequestBody BoardDto boardDto,
-        @RequestAttribute("identification") String identification
-    ) {
-        getPostService.createPost(boardDto.getBoardName(), identification);
-
-        return "OK";
-    }
 }

--- a/src/main/java/com/junstudio/kickoff/controllers/MessageController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/MessageController.java
@@ -22,7 +22,11 @@ public class MessageController {
     public void enter(ChatMessageDto message,
                       SimpMessageHeaderAccessor headerAccessor) {
         message.setMessage(message.getWriter() + "님이 채팅방에 입장하였습니다.");
+
+        message.enter();
+
         messageService.authentication(headerAccessor, message);
+
         template.convertAndSend("/sub/chat/room/" + message.getRoomId(), message);
     }
 

--- a/src/main/java/com/junstudio/kickoff/controllers/UserController.java
+++ b/src/main/java/com/junstudio/kickoff/controllers/UserController.java
@@ -104,7 +104,7 @@ public class UserController {
     public String InValidRequest(MethodArgumentNotValidException exception) {
         BindingResult errors = exception.getBindingResult();
 
-        for(ObjectError error : errors.getAllErrors()) {
+        for (ObjectError error : errors.getAllErrors()) {
             return error.getDefaultMessage();
         }
         return "Bad Request";

--- a/src/main/java/com/junstudio/kickoff/dtos/ChatMessageDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ChatMessageDto.java
@@ -9,6 +9,8 @@ public class ChatMessageDto {
 
     private String name;
 
+    private boolean isEnter = false;
+
     public ChatMessageDto() {
     }
 
@@ -17,6 +19,7 @@ public class ChatMessageDto {
         this.writer = writer;
         this.message = message;
         this.name = name;
+        this.isEnter = false;
     }
 
     public String getRoomId() {
@@ -35,11 +38,19 @@ public class ChatMessageDto {
         return name;
     }
 
+    public boolean isEnter() {
+        return isEnter;
+    }
+
     public void setMessage(String message) {
         this.message = message;
     }
 
     public void name(String name) {
         this.name = name;
+    }
+
+    public void enter() {
+        isEnter = true;
     }
 }

--- a/src/main/java/com/junstudio/kickoff/dtos/ScheduleDto.java
+++ b/src/main/java/com/junstudio/kickoff/dtos/ScheduleDto.java
@@ -1,0 +1,13 @@
+package com.junstudio.kickoff.dtos;
+
+public class ScheduleDto {
+    private final String today;
+
+    public ScheduleDto(String today) {
+        this.today = today;
+    }
+
+    public String getToday() {
+        return today;
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/exceptions/AdminNotFound.java
+++ b/src/main/java/com/junstudio/kickoff/exceptions/AdminNotFound.java
@@ -1,0 +1,7 @@
+package com.junstudio.kickoff.exceptions;
+
+public class AdminNotFound extends RuntimeException {
+    public AdminNotFound() {
+        super("관리자 계정이 아닙니다.");
+    }
+}

--- a/src/main/java/com/junstudio/kickoff/repositories/NotificationRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/NotificationRepository.java
@@ -4,7 +4,6 @@ import com.junstudio.kickoff.models.Notification;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Arrays;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {

--- a/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/PostRepository.java
@@ -20,11 +20,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByPostInformation_TitleContaining(String keyword, Pageable pageable);
 
-    Page<Post> findByBoardIdAndPostInformation_TitleContaining(Long boardId, String keyword, Pageable pageable);
+    Page<Post> findByBoardId_ValueAndPostInformation_TitleContaining(Long boardId, String keyword, Pageable pageable);
 
     Page<Post> findByPostInformation_ContentContaining(String keyword, Pageable pageable);
 
-    Page<Post> findByBoardIdAndPostInformation_ContentContaining(Long boardId, String keyword, Pageable pageable);
+    Page<Post> findByBoardId_ValueAndPostInformation_ContentContaining(Long boardId, String keyword, Pageable pageable);
 
     Page<Post> findByUserId(UserId userId, Pageable pageable);
 

--- a/src/main/java/com/junstudio/kickoff/repositories/SseEmitterRepository.java
+++ b/src/main/java/com/junstudio/kickoff/repositories/SseEmitterRepository.java
@@ -13,12 +13,12 @@ public class SseEmitterRepository {
     public final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
     private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
 
-    public SseEmitter save(String id, SseEmitter sseEmitter){
+    public SseEmitter save(String id, SseEmitter sseEmitter) {
         emitters.put(id, sseEmitter);
         return sseEmitter;
     }
 
-    public void deleteById(String id){
+    public void deleteById(String id) {
         emitters.remove(id);
     }
 

--- a/src/main/java/com/junstudio/kickoff/services/GetNotificationService.java
+++ b/src/main/java/com/junstudio/kickoff/services/GetNotificationService.java
@@ -30,7 +30,8 @@ public class GetNotificationService {
         User user = userRepository.findByIdentification(identification)
             .orElseThrow(UserNotFound::new);
 
-        List<NotificationDto> notifications = notificationRepository.findAllByReceiverId(user.id(), Sort.by(Sort.Direction.DESC, "id"))
+        List<NotificationDto> notifications = notificationRepository
+            .findAllByReceiverId(user.id(), Sort.by(Sort.Direction.DESC, "id"))
             .stream()
             .map(Notification::toDto)
             .collect(Collectors.toList());

--- a/src/main/java/com/junstudio/kickoff/services/NotificationService.java
+++ b/src/main/java/com/junstudio/kickoff/services/NotificationService.java
@@ -45,12 +45,12 @@ public class NotificationService {
 
 //        sendToClient(emitter, id, "Connected!");
 
-        if (!lastEventId.isEmpty()) {
-            Map<String, Object> events = sseEmitterRepository.findAllEventCacheStartWithId(String.valueOf(userId));
-            events.entrySet().stream()
-                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
-                .forEach(entry -> sendToClient(emitter, entry.getKey(), entry.getValue()));
-        }
+//        if (!lastEventId.isEmpty()) {
+//            Map<String, Object> events = sseEmitterRepository.findAllEventCacheStartWithId(String.valueOf(userId));
+//            events.entrySet().stream()
+//                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+//                .forEach(entry -> sendToClient(emitter, entry.getKey(), entry.getValue()));
+//        }
 
         return emitter;
     }

--- a/src/test/java/com/junstudio/kickoff/admin/controllers/AdminPostControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/controllers/AdminPostControllerTest.java
@@ -7,14 +7,15 @@ import com.junstudio.kickoff.dtos.StatisticsPostsDto;
 import com.junstudio.kickoff.dtos.TodayCreatePostsDto;
 import com.junstudio.kickoff.models.Post;
 import com.junstudio.kickoff.models.User;
+import com.junstudio.kickoff.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.List;
 
@@ -32,6 +33,12 @@ class AdminPostControllerTest {
     @MockBean
     private GetPostAdminService getPostAdminService;
 
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    String token;
+    String identification;
+
     Post post;
     User user;
 
@@ -39,6 +46,10 @@ class AdminPostControllerTest {
     void setup() {
         post = Post.fake();
         user = User.fake();
+
+        identification = "je1ly";
+
+        token = jwtUtil.encode(identification);
     }
 
     @Test
@@ -83,10 +94,11 @@ class AdminPostControllerTest {
 
     @Test
     void weekPosts() throws Exception {
-        given(getPostAdminService.weekPosts())
+        given(getPostAdminService.weekPosts(identification))
             .willReturn(new PostsByDateDto(1, 2, 3, 4, 5, 6, 7));
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/admin-week-posts"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin-week-posts")
+                .header("Authorization", "Bearer " + token))
             .andExpect(status().isOk())
             .andExpect(content().string(
                 containsString("{" +
@@ -100,7 +112,7 @@ class AdminPostControllerTest {
                     "}")
             ));
 
-        verify(getPostAdminService).weekPosts();
+        verify(getPostAdminService).weekPosts(identification);
     }
 
     @Test

--- a/src/test/java/com/junstudio/kickoff/admin/services/GetPostAdminServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/admin/services/GetPostAdminServiceTest.java
@@ -63,9 +63,11 @@ class GetPostAdminServiceTest {
 
     @Test
     void weekPosts() {
+        given(userRepository.findByIdentification(any())).willReturn(Optional.of(user));
+
         given(postRepository.findByCreatedAtBetween(any(), any())).willReturn(List.of(post));
 
-        PostsByDateDto postsNumber = getPostAdminService.weekPosts();
+        PostsByDateDto postsNumber = getPostAdminService.weekPosts(user.identification());
 
         assertThat(postsNumber.getTodayPostsNumber()).isEqualTo(1);
     }

--- a/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
+++ b/src/test/java/com/junstudio/kickoff/controllers/CommentControllerTest.java
@@ -25,7 +25,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import javax.persistence.Embedded;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/src/test/java/com/junstudio/kickoff/repositories/SseEmitterRepositoryTest.java
+++ b/src/test/java/com/junstudio/kickoff/repositories/SseEmitterRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.junstudio.kickoff.repositories;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+class SseEmitterRepositoryTest {
+//    @Test
+//    void save() {
+//        SseEmitterRepository sseEmitterRepository = new SseEmitterRepository();
+//
+//        String id = "jel1y";
+//        SseEmitter sseEmitter = new SseEmitter();
+//
+//        for (int i = 0; i < 5000; i += 1) {
+//            sseEmitterRepository.save(id, sseEmitter);
+//        }
+//    }
+
+    @Test
+    void hashMap() throws InterruptedException {
+        HashMap<String, String> hashMap = new HashMap<>();
+
+        String key = "key";
+        String value = "value";
+
+        int numberOfThreads = 3;
+
+        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i += 1) {
+            executor.submit(() -> {
+                hashMap.put(key, value);
+                System.out.println(hashMap.get(key));
+                System.out.println("1: " + Thread.currentThread().getName());
+
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+
+//        for (int i = 0; i < 5; i += 1) {
+//            executor.submit(() -> {
+//                hashMap.put(key, value);
+//                System.out.println(hashMap.get(key));
+//                System.out.println("1: " + Thread.currentThread().getName());
+//            });
+//        }
+
+//        executor.submit(() -> {
+//            hashMap.put(key, value);
+//            System.out.println(hashMap.get(key));
+//            System.out.println("1: " + Thread.currentThread().getName());
+//        });
+//
+//        executor.submit(() -> {
+//            hashMap.put(key, value);
+//            System.out.println(hashMap.get(key));
+//            System.out.println("2: " + Thread.currentThread().getName());
+//        });
+//
+//        executor.submit(() -> {
+//            hashMap.put(key, value);
+//            System.out.println(hashMap.get(key));
+//            System.out.println("3: " + Thread.currentThread().getName());
+//        });
+    }
+
+    @Test
+    void concurrentHashMap() {
+        ConcurrentHashMap<String, String> concurrentHashMap = new ConcurrentHashMap<>();
+
+        String key = "key";
+        String value = "value";
+
+        int numberOfThreads = 3;
+
+        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+
+//        for (int i = 1; i <= numberOfThreads; i += 1) {
+//            String value = String.valueOf(i);
+//            executor.submit(() -> {
+//                System.out.println(concurrentHashMap.put(key, value));
+////                System.out.println(concurrentHashMap.get(key));
+////                System.out.println(Thread.currentThread().getName());
+//            });
+//        }
+//
+        executor.submit(() -> {
+            System.out.println(concurrentHashMap.put(key, value));
+
+//            concurrentHashMap.put(key, value);
+//            System.out.println(concurrentHashMap.get(key));
+//            System.out.println("1: " + Thread.currentThread().getName());
+        });
+
+        executor.submit(() -> {
+            System.out.println(concurrentHashMap.put(key, value));
+
+//            concurrentHashMap.put(key, value);
+//            System.out.println(concurrentHashMap.get(key));
+//            System.out.println("2: " + Thread.currentThread().getName());
+        });
+
+        executor.submit(() -> {
+            System.out.println(concurrentHashMap.put(key, value));
+//            concurrentHashMap.put(key, value);
+//            System.out.println(concurrentHashMap.get(key));
+//            System.out.println("3: " + Thread.currentThread().getName());
+        });
+    }
+}

--- a/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
+++ b/src/test/java/com/junstudio/kickoff/services/GetPostServiceTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class GetPostServiceTest {
@@ -139,7 +140,7 @@ class GetPostServiceTest {
             "Laliga", Pageable.ofSize(1))
         ).willReturn(page);
 
-        given(postRepository.findByBoardIdAndPostInformation_TitleContaining(
+        given(postRepository.findByBoardId_ValueAndPostInformation_TitleContaining(
             2L, "Laliga", Pageable.ofSize(1))
         ).willReturn(page);
 
@@ -150,7 +151,7 @@ class GetPostServiceTest {
             .getPostInformation().getTitle())
             .isEqualTo("Laliga start");
 
-        verify(postRepository).findByBoardIdAndPostInformation_TitleContaining(any(), any(), any());
+        verify(postRepository).findByBoardId_ValueAndPostInformation_TitleContaining(any(), any(), any());
     }
 
     @Test
@@ -164,14 +165,6 @@ class GetPostServiceTest {
 
         Page<Post> page = new PageImpl<>(posts);
 
-        given(postRepository.findByPostInformation_TitleContaining(
-            "이강인", Pageable.ofSize(1))
-        ).willReturn(page);
-
-        given(postRepository.findByPostInformation_ContentContaining(
-            "이강인", Pageable.ofSize(1))
-        ).willReturn(page);
-
         given(postRepository.findByPostInformation_ContentContaining(
             "이강인", Pageable.ofSize(1))
         ).willReturn(page);
@@ -183,6 +176,6 @@ class GetPostServiceTest {
             .getPostInformation().getContent())
             .isEqualTo("이강인 개막전 득점");
 
-        verify(postRepository).findByPostInformation_ContentContaining(any(), any());
+        verify(postRepository, times(3)).findByPostInformation_ContentContaining(any(), any());
     }
 }


### PR DESCRIPTION
- 하루에 100번 요청 할 수 있도록 100개의 버킷 생성해서 관리
- 게시글 작성자 기준으로 검색 시 페이지네이션 안되는 문제 수정